### PR TITLE
refactor: wrap guard builders with define

### DIFF
--- a/src/core/combinators/array.ts
+++ b/src/core/combinators/array.ts
@@ -1,3 +1,4 @@
+import { define } from '../define';
 import type { GuardedOf, Predicate } from '@/types';
 
 /**
@@ -9,11 +10,11 @@ import type { GuardedOf, Predicate } from '@/types';
 export function arrayOf<F extends Predicate<unknown>>(
   elementGuard: F
 ): Predicate<readonly GuardedOf<F>[]> {
-  return (input: unknown): input is readonly GuardedOf<F>[] => {
+  return define<readonly GuardedOf<F>[]>((input) => {
     if (!Array.isArray(input)) return false;
     for (const element of input as readonly unknown[]) {
       if (!elementGuard(element)) return false;
     }
     return true;
-  };
+  });
 }

--- a/src/core/combinators/one-of-values.ts
+++ b/src/core/combinators/one-of-values.ts
@@ -25,9 +25,9 @@ const normalizeValues = (
 const createLinearPredicate = (
   items: readonly Primitive[]
 ): Predicate<Primitive> => {
-  return (input: unknown): input is Primitive => {
+  return define<Primitive>((input) => {
     return items.some((value) => Object.is(value, input));
-  };
+  });
 };
 
 const createSetPredicate = (
@@ -48,12 +48,12 @@ const createSetPredicate = (
     }
   }
 
-  return (input: unknown): input is Primitive => {
+  return define<Primitive>((input) => {
     if (isZeroNumber(input)) {
       return Object.is(input, -0) ? hasNegativeZero : hasPositiveZero;
     }
     return valueSet.has(input);
-  };
+  });
 };
 
 /**

--- a/src/core/combinators/one-of.ts
+++ b/src/core/combinators/one-of.ts
@@ -1,4 +1,3 @@
-import { define } from '../define';
 import type { GuardedOf, GuardedWithin, Predicate } from '@/types';
 import { toBooleanPredicates } from '@/utils';
 
@@ -18,7 +17,5 @@ export function oneOf(
   ...guards: readonly ((input: unknown) => input is unknown)[]
 ) {
   const predicates = toBooleanPredicates(guards);
-  return define<GuardedOf<(typeof guards)[number]>>((input) =>
-    predicates.some((guard) => guard(input))
-  );
+  return (input: unknown) => predicates.some((guard) => guard(input));
 }

--- a/src/core/combinators/one-of.ts
+++ b/src/core/combinators/one-of.ts
@@ -1,3 +1,4 @@
+import { define } from '../define';
 import type { GuardedOf, GuardedWithin, Predicate } from '@/types';
 import { toBooleanPredicates } from '@/utils';
 
@@ -17,5 +18,7 @@ export function oneOf(
   ...guards: readonly ((input: unknown) => input is unknown)[]
 ) {
   const predicates = toBooleanPredicates(guards);
-  return (input: unknown) => predicates.some((guard) => guard(input));
+  return define<GuardedOf<(typeof guards)[number]>>((input) =>
+    predicates.some((guard) => guard(input))
+  );
 }

--- a/src/core/combinators/struct.ts
+++ b/src/core/combinators/struct.ts
@@ -89,7 +89,7 @@ export function struct<S extends Schema>(
 
   const allowed = options?.exact ? new Set(schemaKeys) : null;
 
-  return (input: unknown): input is InferSchema<S> => {
+  return define<InferSchema<S>>((input) => {
     if (!isPlainObject(input)) return false;
     const obj = input;
 
@@ -97,5 +97,5 @@ export function struct<S extends Schema>(
     if (!hasValidOptionalKeys(obj, optionalEntries)) return false;
     if (!allowed) return true;
     return hasOnlyAllowedKeys(obj, allowed);
-  };
+  });
 }

--- a/src/core/combinators/tuple.ts
+++ b/src/core/combinators/tuple.ts
@@ -1,3 +1,4 @@
+import { define } from '../define';
 import type { Predicate, GuardedOf } from '@/types';
 
 /**
@@ -9,9 +10,7 @@ import type { Predicate, GuardedOf } from '@/types';
 export function tupleOf<const Fs extends readonly Predicate<unknown>[]>(
   ...guards: Fs
 ): Predicate<{ readonly [K in keyof Fs]: GuardedOf<Fs[K]> }> {
-  return (
-    input: unknown
-  ): input is { readonly [K in keyof Fs]: GuardedOf<Fs[K]> } => {
+  return define<{ readonly [K in keyof Fs]: GuardedOf<Fs[K]> }>((input) => {
     return (
       Array.isArray(input) &&
       input.length === guards.length &&
@@ -19,5 +18,5 @@ export function tupleOf<const Fs extends readonly Predicate<unknown>[]>(
         guard((input as readonly unknown[])[index])
       )
     );
-  };
+  });
 }

--- a/src/core/logic.ts
+++ b/src/core/logic.ts
@@ -6,6 +6,7 @@ import type {
   OutOfGuards,
   Predicate
 } from '@/types';
+import { define } from './define';
 import { toBooleanPredicates } from '@/utils';
 
 /**
@@ -19,12 +20,12 @@ export function and<A, B extends A>(
   precondition: Guard<A>,
   condition: Refine<A, B>
 ): Predicate<B> {
-  return (input: unknown): input is B => {
+  return define<B>((input) => {
     if (precondition(input)) {
       return condition(input);
     }
     return false;
-  };
+  });
 }
 
 /**
@@ -48,10 +49,10 @@ export function andAll<A, Chain extends readonly Refine<unknown, unknown>[]>(
   precondition: Guard<A>,
   ...steps: Chain & RefineChain<A, Chain>
 ): Guard<ChainResult<A, Chain>> {
-  return (input: unknown): input is ChainResult<A, Chain> => {
+  return define<ChainResult<A, Chain>>((input) => {
     if (!precondition(input)) return false;
     return applyRefinements(input, steps);
-  };
+  });
 }
 
 /**
@@ -64,9 +65,9 @@ export function or<P extends readonly Guard<unknown>[]>(
   ...guards: P
 ): Guard<OutOfGuards<P>> {
   const predicates = toBooleanPredicates(guards);
-  return (input: unknown): input is OutOfGuards<P> => {
-    return predicates.some((guard) => guard(input));
-  };
+  return define<OutOfGuards<P>>((input) =>
+    predicates.some((guard) => guard(input))
+  );
 }
 
 /**


### PR DESCRIPTION
## Summary

Wrap guard builders with define.

<!-- A brief summary of the changes -->

## Description

- Wrap guard-producing returns in `define(...)` across core logic and combinators.
- Preserve existing guard composition and runtime behavior while standardizing predicate construction.

<!-- A detailed explanation of the changes, including why they are needed -->
