### PR TITLE
chore: enforce 48-hour minimum package age

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -30,7 +30,8 @@ Using mise tasks:
 
 Security note:
 
-- Root `pnpm-workspace.yaml` sets `minimumReleaseAge: 2880`, so `pnpm install` blocks packages published within the last 48 hours unless explicitly excluded later.
+- Root `pnpm-workspace.yaml` sets `minimumReleaseAge: 2880` (minutes = 48 hours), so `pnpm install` blocks packages published within the last 48 hours by default.
+- If a legitimate new dependency is blocked, add an explicit exception in the root `pnpm-workspace.yaml` allowlist/exception configuration for `minimumReleaseAge` rather than bypassing the check locally, and include a brief justification in the PR.
 
 ## Project Map
 

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -28,6 +28,10 @@ Using mise tasks:
 - Type tests: `mise run test-types`
 - CI all: `mise run ci` (lint + build + test + type tests)
 
+Security note:
+
+- Root `pnpm-workspace.yaml` sets `minimumReleaseAge: 2880`, so `pnpm install` blocks packages published within the last 48 hours unless explicitly excluded later.
+
 ## Project Map
 
 - src/ TypeScript sources (ESM, strict)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,10 @@ packages:
   - .
   - docs
 
+# WHY: Delay installs of newly published packages for 48 hours to reduce
+# exposure to compromised releases before the ecosystem has time to react.
+minimumReleaseAge: 2880
+
 ignoredBuiltDependencies:
   - esbuild
   - lefthook


### PR DESCRIPTION
## Summary

<!-- A brief summary of the changes -->

## Description

- Configure pnpm at the workspace root to block installing packages published within the last 48 hours.
- Use `minimumReleaseAge: 2880` in `pnpm-workspace.yaml` so the policy applies consistently across the root package and docs workspace.
- Document the install-time security policy in `DEVELOPER.md` so contributors understand why recent packages may be rejected.

<!-- A detailed explanation of the changes, including why they are needed -->
