### PR TITLE
refactor(core): use Object.hasOwn for own-property checks

### DIFF
--- a/src/core/combinators/struct.ts
+++ b/src/core/combinators/struct.ts
@@ -9,9 +9,6 @@ import { isObject, isPlainObject } from '../object';
 
 type SchemaEntry = readonly [key: string, guard: Predicate<unknown>];
 
-const hasOwnKey = (obj: Record<string, unknown>, key: string): boolean =>
-  Object.prototype.hasOwnProperty.call(obj, key);
-
 const isOptionalSchemaField = define<OptionalSchemaField<Predicate<unknown>>>(
   // WHY: Optional fields are represented as a small tagged object so `struct`
   // can distinguish schema metadata from plain predicate functions up front.
@@ -27,7 +24,7 @@ const hasRequiredKeys = (
 ): boolean =>
   // WHY: Required fields must be own properties; inherited values should not
   // satisfy a schema because `struct` models object payload shape, not prototype chains.
-  entries.every(([key, guard]) => hasOwnKey(obj, key) && guard(obj[key]));
+  entries.every(([key, guard]) => Object.hasOwn(obj, key) && guard(obj[key]));
 
 const hasValidOptionalKeys = (
   obj: Record<string, unknown>,
@@ -35,7 +32,7 @@ const hasValidOptionalKeys = (
 ): boolean =>
   // WHY: Optional keys are validated only when present. Missing keys stay valid
   // without forcing callers to encode `undefined` into the value guard.
-  entries.every(([key, guard]) => !hasOwnKey(obj, key) || guard(obj[key]));
+  entries.every(([key, guard]) => !Object.hasOwn(obj, key) || guard(obj[key]));
 
 const hasOnlyAllowedKeys = (
   obj: Record<string, unknown>,

--- a/src/core/equals.ts
+++ b/src/core/equals.ts
@@ -71,7 +71,7 @@ export function equalsKey<K extends PropertyKey, const T>(
   const hasMatchingKey = define<Record<K, T>>((input) => {
     return (
       isObject(input) &&
-      Object.prototype.hasOwnProperty.call(input, key) &&
+      Object.hasOwn(input, key) &&
       Object.is(input[key], target)
     );
   });

--- a/src/core/key.ts
+++ b/src/core/key.ts
@@ -11,8 +11,7 @@ import { isObject } from './object';
  */
 export const hasKey = <K extends PropertyKey>(key: K) =>
   define<Record<K, unknown>>(
-    (input) =>
-      isObject(input) && Object.prototype.hasOwnProperty.call(input, key)
+    (input) => isObject(input) && Object.hasOwn(input, key)
   );
 
 /**
@@ -33,9 +32,7 @@ export const hasKeys = <
   }
 
   return define<Record<KS[number], unknown>>(
-    (input) =>
-      isObject(input) &&
-      keys.every((key) => Object.prototype.hasOwnProperty.call(input, key))
+    (input) => isObject(input) && keys.every((key) => Object.hasOwn(input, key))
   );
 };
 


### PR DESCRIPTION
## Summary

Use `Object.hasOwn` for own-property checks

<!-- A brief summary of the changes -->

## Description

- Replace legacy `Object.prototype.hasOwnProperty.call(...)` usage in core with `Object.hasOwn(...)`.
- Remove the now-unnecessary local own-key helper in struct.
- Keep behavior unchanged while aligning the implementation with the repository’s ES2022 target and improving readability.

<!-- A detailed explanation of the changes, including why they are needed -->
