### PR TITLE
refactor(core): extract reusable guard collection helpers

### DIFF
--- a/src/core/combinators/array.ts
+++ b/src/core/combinators/array.ts
@@ -1,5 +1,6 @@
 import { define } from '../define';
 import type { GuardedOf, Predicate } from '@/types';
+import { everyArrayValue } from '@/utils';
 
 /**
  * Validates an array where every element satisfies the provided guard.
@@ -10,11 +11,7 @@ import type { GuardedOf, Predicate } from '@/types';
 export function arrayOf<F extends Predicate<unknown>>(
   elementGuard: F
 ): Predicate<readonly GuardedOf<F>[]> {
-  return define<readonly GuardedOf<F>[]>((input) => {
-    if (!Array.isArray(input)) return false;
-    for (const element of input as readonly unknown[]) {
-      if (!elementGuard(element)) return false;
-    }
-    return true;
-  });
+  return define<readonly GuardedOf<F>[]>(
+    (input) => Array.isArray(input) && everyArrayValue(input, elementGuard)
+  );
 }

--- a/src/core/combinators/map.ts
+++ b/src/core/combinators/map.ts
@@ -1,5 +1,6 @@
 import type { GuardedOf, Predicate } from '@/types';
 import { define } from '../define';
+import { everyMapEntry } from '@/utils';
 import { isMap } from '../object';
 
 /**
@@ -16,14 +17,7 @@ export function mapOf<
   keyGuard: KF,
   valueGuard: VF
 ): Predicate<ReadonlyMap<GuardedOf<KF>, GuardedOf<VF>>> {
-  return define<ReadonlyMap<GuardedOf<KF>, GuardedOf<VF>>>((input) => {
-    if (!isMap(input)) return false;
-
-    for (const [key, value] of input.entries()) {
-      if (!keyGuard(key)) return false;
-      if (!valueGuard(value)) return false;
-    }
-
-    return true;
-  });
+  return define<ReadonlyMap<GuardedOf<KF>, GuardedOf<VF>>>(
+    (input) => isMap(input) && everyMapEntry(input, keyGuard, valueGuard)
+  );
 }

--- a/src/core/combinators/one-of.ts
+++ b/src/core/combinators/one-of.ts
@@ -1,5 +1,5 @@
 import type { GuardedOf, GuardedWithin, Predicate } from '@/types';
-import { toBooleanPredicates } from '@/utils';
+import { or } from '../logic';
 
 /**
  * Combines multiple guards; passes when any one guard matches.
@@ -16,6 +16,5 @@ export function oneOf<A, Fs extends readonly Predicate<A>[]>(
 export function oneOf(
   ...guards: readonly ((input: unknown) => input is unknown)[]
 ) {
-  const predicates = toBooleanPredicates(guards);
-  return (input: unknown) => predicates.some((guard) => guard(input));
+  return or(...guards);
 }

--- a/src/core/combinators/record.ts
+++ b/src/core/combinators/record.ts
@@ -1,4 +1,6 @@
 import type { GuardedOf, Predicate } from '@/types';
+import { define } from '../define';
+import { everyOwnEnumerableEntry } from '@/utils';
 import { isPlainObject } from '../object';
 
 /**
@@ -15,18 +17,9 @@ export function recordOf<
   keyFunction: KF,
   valueFunction: VF
 ): Predicate<Readonly<Record<GuardedOf<KF>, GuardedOf<VF>>>> {
-  return (
-    input: unknown
-  ): input is Readonly<Record<GuardedOf<KF>, GuardedOf<VF>>> => {
-    if (!isPlainObject(input)) return false;
-
-    const obj = input;
-
-    for (const key of Object.keys(obj)) {
-      if (!keyFunction(key)) return false;
-      const value = obj[key];
-      if (!valueFunction(value)) return false;
-    }
-    return true;
-  };
+  return define<Readonly<Record<GuardedOf<KF>, GuardedOf<VF>>>>(
+    (input) =>
+      isPlainObject(input) &&
+      everyOwnEnumerableEntry(input, keyFunction, valueFunction)
+  );
 }

--- a/src/core/combinators/set.ts
+++ b/src/core/combinators/set.ts
@@ -1,5 +1,6 @@
 import type { GuardedOf, Predicate } from '@/types';
 import { define } from '../define';
+import { everySetValue } from '@/utils';
 import { isSet } from '../object';
 
 /**
@@ -11,13 +12,7 @@ import { isSet } from '../object';
 export function setOf<VF extends Predicate<unknown>>(
   valueGuard: VF
 ): Predicate<ReadonlySet<GuardedOf<VF>>> {
-  return define<ReadonlySet<GuardedOf<VF>>>((input) => {
-    if (!isSet(input)) return false;
-
-    for (const value of input.values()) {
-      if (!valueGuard(value)) return false;
-    }
-
-    return true;
-  });
+  return define<ReadonlySet<GuardedOf<VF>>>(
+    (input) => isSet(input) && everySetValue(input, valueGuard)
+  );
 }

--- a/src/core/combinators/tuple.ts
+++ b/src/core/combinators/tuple.ts
@@ -1,5 +1,6 @@
 import { define } from '../define';
 import type { Predicate, GuardedOf } from '@/types';
+import { everyTupleValue } from '@/utils';
 
 /**
  * Validates a fixed-length tuple by applying element-wise guards.
@@ -10,13 +11,7 @@ import type { Predicate, GuardedOf } from '@/types';
 export function tupleOf<const Fs extends readonly Predicate<unknown>[]>(
   ...guards: Fs
 ): Predicate<{ readonly [K in keyof Fs]: GuardedOf<Fs[K]> }> {
-  return define<{ readonly [K in keyof Fs]: GuardedOf<Fs[K]> }>((input) => {
-    return (
-      Array.isArray(input) &&
-      input.length === guards.length &&
-      guards.every((guard, index) =>
-        guard((input as readonly unknown[])[index])
-      )
-    );
-  });
+  return define<{ readonly [K in keyof Fs]: GuardedOf<Fs[K]> }>(
+    (input) => Array.isArray(input) && everyTupleValue(input, guards)
+  );
 }

--- a/src/core/nullish.ts
+++ b/src/core/nullish.ts
@@ -1,5 +1,15 @@
 import type { Guard, Refine } from '@/types';
 
+const allowWhen = (
+  acceptedValue: (value: unknown) => boolean,
+  predicate: (value: unknown) => boolean
+) => (value: unknown) => acceptedValue(value) || predicate(value);
+
+const requireWhen = (
+  rejectedValue: (value: unknown) => boolean,
+  predicate: (value: unknown) => boolean
+) => (value: unknown) => !rejectedValue(value) && predicate(value);
+
 /**
  * Allows `null` in addition to values accepted by the given guard/refinement.
  *
@@ -11,7 +21,7 @@ export function nullable<A, B extends A>(
   refine: Refine<A, B>
 ): Refine<A | null, B | null>;
 export function nullable(fn: (value: unknown) => boolean) {
-  return (value: unknown) => value === null || fn(value);
+  return allowWhen((value) => value === null, fn);
 }
 
 /**
@@ -25,7 +35,7 @@ export function nonNull<A, B extends A>(
   refine: Refine<A, B>
 ): Refine<Exclude<A, null>, Exclude<B, null>>;
 export function nonNull(fn: (value: unknown) => boolean) {
-  return (value: unknown) => value !== null && fn(value);
+  return requireWhen((value) => value === null, fn);
 }
 
 /**
@@ -39,7 +49,7 @@ export function nullish<A, B extends A>(
   refine: Refine<A, B>
 ): Refine<A | null | undefined, B | null | undefined>;
 export function nullish(fn: (value: unknown) => boolean) {
-  return (value: unknown) => value == null || fn(value);
+  return allowWhen((value) => value == null, fn);
 }
 
 /**
@@ -53,7 +63,7 @@ export function optional<A, B extends A>(
   refine: Refine<A, B>
 ): Refine<A | undefined, B | undefined>;
 export function optional(fn: (value: unknown) => boolean) {
-  return (value: unknown) => value === undefined || fn(value);
+  return allowWhen((value) => value === undefined, fn);
 }
 
 /**
@@ -67,5 +77,5 @@ export function required<A, B extends A>(
   refine: Refine<A | undefined, B | undefined>
 ): Refine<A, B>;
 export function required(fn: (value: unknown) => boolean) {
-  return (value: unknown) => value !== undefined && fn(value);
+  return requireWhen((value) => value === undefined, fn);
 }

--- a/src/utils/guard-collections.ts
+++ b/src/utils/guard-collections.ts
@@ -1,0 +1,91 @@
+/**
+ * Checks whether every array element satisfies the provided predicate.
+ *
+ * @param values Array values to validate.
+ * @param predicate Predicate applied to each element.
+ * @returns Whether all elements satisfy `predicate`.
+ */
+export const everyArrayValue = (
+  values: readonly unknown[],
+  predicate: (value: unknown) => boolean
+): boolean => {
+  for (const value of values) {
+    if (!predicate(value)) return false;
+  }
+  return true;
+};
+
+/**
+ * Checks whether a tuple matches the provided element predicates in order.
+ *
+ * @param values Tuple candidate values.
+ * @param predicates Predicates aligned to each tuple index.
+ * @returns Whether lengths match and each index passes.
+ */
+export const everyTupleValue = (
+  values: readonly unknown[],
+  predicates: readonly ((value: unknown) => boolean)[]
+): boolean => {
+  if (values.length !== predicates.length) return false;
+
+  for (const [index, predicate] of predicates.entries()) {
+    if (!predicate(values[index])) return false;
+  }
+
+  return true;
+};
+
+/**
+ * Checks whether every set value satisfies the provided predicate.
+ *
+ * @param values Set values to validate.
+ * @param predicate Predicate applied to each value.
+ * @returns Whether all set values satisfy `predicate`.
+ */
+export const everySetValue = (
+  values: ReadonlySet<unknown>,
+  predicate: (value: unknown) => boolean
+): boolean => {
+  for (const value of values) {
+    if (!predicate(value)) return false;
+  }
+  return true;
+};
+
+/**
+ * Checks whether every map entry satisfies the provided key and value predicates.
+ *
+ * @param values Map values to validate.
+ * @param keyPredicate Predicate applied to each key.
+ * @param valuePredicate Predicate applied to each value.
+ * @returns Whether all keys and values satisfy their predicates.
+ */
+export const everyMapEntry = (
+  values: ReadonlyMap<unknown, unknown>,
+  keyPredicate: (value: unknown) => boolean,
+  valuePredicate: (value: unknown) => boolean
+): boolean => {
+  for (const [key, value] of values) {
+    if (!keyPredicate(key) || !valuePredicate(value)) return false;
+  }
+  return true;
+};
+
+/**
+ * Checks whether every own enumerable string key/value pair satisfies the provided predicates.
+ *
+ * @param values Plain object values to validate.
+ * @param keyPredicate Predicate applied to each enumerable own string key.
+ * @param valuePredicate Predicate applied to each corresponding value.
+ * @returns Whether all enumerable entries satisfy their predicates.
+ */
+export const everyOwnEnumerableEntry = (
+  values: Record<string, unknown>,
+  keyPredicate: (key: string) => boolean,
+  valuePredicate: (value: unknown) => boolean
+): boolean => {
+  for (const key of Object.keys(values)) {
+    if (!keyPredicate(key) || !valuePredicate(values[key])) return false;
+  }
+  return true;
+};

--- a/src/utils/guard-collections.ts
+++ b/src/utils/guard-collections.ts
@@ -62,7 +62,7 @@ export const everySetValue = (
  */
 export const everyMapEntry = (
   values: ReadonlyMap<unknown, unknown>,
-  keyPredicate: (value: unknown) => boolean,
+  keyPredicate: (key: unknown) => boolean,
   valuePredicate: (value: unknown) => boolean
 ): boolean => {
   for (const [key, value] of values) {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,1 +1,2 @@
+export * from './guard-collections';
 export * from './to-boolean-predicates';


### PR DESCRIPTION
## Summary

Extract reusable guard collection helpers

<!-- A brief summary of the changes -->

## Description

- Extract shared guard-driven collection traversal helpers into `utils/guard-collections.ts` and export them from `utils/index.ts`.
- Refactor the core combinators to reuse those helpers instead of duplicating array, tuple, set, map, and record traversal logic.
- Simplify `oneOf` by delegating to or, and reduce repetition in `core/nullish.ts` with shared local helper functions.
- Keep runtime behavior unchanged while making the internal implementation flatter and easier to maintain.

<!-- A detailed explanation of the changes, including why they are needed -->
