### PR TITLE
refactor: clean up object guard internals

### DIFF
--- a/src/core/object.ts
+++ b/src/core/object.ts
@@ -13,12 +13,14 @@ import {
   OBJECT_TAG_WEAK_SET
 } from '@/utils/object-tags';
 
+type AnyFunction = (...args: never[]) => unknown;
+
 /**
  * Checks whether a value is a function.
  *
- * @returns Predicate narrowing to `Function`.
+ * @returns Predicate narrowing to a callable value.
  */
-export const isFunction = define<Function>(
+export const isFunction = define<AnyFunction>(
   (value) => typeof value === 'function'
 );
 
@@ -30,6 +32,11 @@ export const isFunction = define<Function>(
 export const isObject = define<Record<PropertyKey, unknown>>(
   (value) => typeof value === 'object' && value !== null
 );
+
+const readObjectProperty = (value: unknown, key: PropertyKey): unknown => {
+  if (!isObject(value) && !isFunction(value)) return undefined;
+  return (value as Record<PropertyKey, unknown>)[key];
+};
 
 /**
  * Checks for plain objects created by object literals or `Object.create(null)`.
@@ -109,30 +116,27 @@ export const isWeakSet = define<WeakSet<object>>(
  *
  * @returns Predicate narrowing to `PromiseLike<unknown>`.
  */
-export const isPromiseLike = define<PromiseLike<unknown>>((value) => {
-  if (!isObject(value) && !isFunction(value)) return false;
-  return isFunction((value as Record<string, unknown>).then);
-});
+export const isPromiseLike = define<PromiseLike<unknown>>((value) =>
+  isFunction(readObjectProperty(value, 'then'))
+);
 
 /**
  * Checks whether a value implements the `Iterable` protocol.
  *
  * @returns Predicate narrowing to `Iterable<unknown>`.
  */
-export const isIterable = define<Iterable<unknown>>((value) => {
-  if (!isObject(value) && !isFunction(value)) return false;
-  return isFunction((value as Record<symbol, unknown>)[Symbol.iterator]);
-});
+export const isIterable = define<Iterable<unknown>>((value) =>
+  isFunction(readObjectProperty(value, Symbol.iterator))
+);
 
 /**
  * Checks whether a value implements the `AsyncIterable` protocol.
  *
  * @returns Predicate narrowing to `AsyncIterable<unknown>`.
  */
-export const isAsyncIterable = define<AsyncIterable<unknown>>((value) => {
-  if (!isObject(value) && !isFunction(value)) return false;
-  return isFunction((value as Record<symbol, unknown>)[Symbol.asyncIterator]);
-});
+export const isAsyncIterable = define<AsyncIterable<unknown>>((value) =>
+  isFunction(readObjectProperty(value, Symbol.asyncIterator))
+);
 
 /**
  * Checks whether a value is an `ArrayBuffer`.

--- a/tests-d/core/object.test-d.ts
+++ b/tests-d/core/object.test-d.ts
@@ -26,7 +26,7 @@ import {
 // =============================================
 // describe: object guards (types)
 // =============================================
-expectType<Predicate<Function>>(isFunction);
+expectType<Predicate<(...args: never[]) => unknown>>(isFunction);
 expectType<Predicate<Record<PropertyKey, unknown>>>(isObject);
 expectType<Predicate<Record<string, unknown>>>(isPlainObject);
 expectType<Predicate<readonly unknown[]>>(isArray);

--- a/tests/core/object.test.ts
+++ b/tests/core/object.test.ts
@@ -52,17 +52,29 @@ describe('core/object guards', () => {
 
     const pLike = { then: () => {} };
     expect(isPromiseLike(pLike)).toBe(true);
+    expect(isPromiseLike(Object.assign(() => {}, pLike))).toBe(true);
     expect(isPromiseLike({})).toBe(false);
   });
 
   it('detects iterable and async iterable', () => {
+    const iterableFunction = Object.assign(() => {}, {
+      [Symbol.iterator]: function* () {}
+    });
+
     expect(isIterable([1, 2, 3])).toBe(true);
+    expect(isIterable(iterableFunction)).toBe(true);
     expect(isIterable({})).toBe(false);
 
     async function* gen() {
       yield 1;
     }
+
+    const asyncIterableFunction = Object.assign(() => {}, {
+      [Symbol.asyncIterator]: async function* () {}
+    });
+
     expect(isAsyncIterable(gen())).toBe(true);
+    expect(isAsyncIterable(asyncIterableFunction)).toBe(true);
     expect(isAsyncIterable([])).toBe(false);
   });
 


### PR DESCRIPTION
## Summary

Clean up object guard internals.

<!-- A brief summary of the changes -->

## Description

- Refactor protocol-style object guards to share a property-read helper for object/function values
- Narrow `isFunction` to a callable signature instead of the broad `Function` type
- Add runtime coverage for function objects with `then`, `Symbol.iterator`, and `Symbol.asyncIterator`

<!-- A detailed explanation of the changes, including why they are needed -->
