### PR TITLE
refactor: centralize platform instance guards

### DIFF
--- a/src/core/object.ts
+++ b/src/core/object.ts
@@ -13,16 +13,22 @@ import {
   OBJECT_TAG_WEAK_SET
 } from '@/utils/object-tags';
 
-type InstanceConstructor<T> = Function & { readonly prototype: T };
+// WHY: DOM constructors such as URL and Blob are declared as constructor
+// objects with a prototype, not as the full Function interface. The helper
+// only needs the prototype for typing; it checks function-ness at runtime
+// before using the value as the right-hand side of `instanceof`.
+type InstanceCheckTarget<T> = { readonly prototype: T };
 
 type AnyFunction = (...args: never[]) => unknown;
 
 const defineOptionalInstanceGuard = <T>(
-  constructor: InstanceConstructor<T> | undefined
+  constructor: InstanceCheckTarget<T> | undefined
 ): Guard<T> =>
   constructor === undefined
     ? define<T>(() => false)
-    : define<T>((value) => value instanceof constructor);
+    : define<T>(
+        (value) => typeof constructor === 'function' && value instanceof constructor
+      );
 
 /**
  * Checks whether a value is a function.

--- a/src/core/object.ts
+++ b/src/core/object.ts
@@ -13,6 +13,15 @@ import {
   OBJECT_TAG_WEAK_SET
 } from '@/utils/object-tags';
 
+type InstanceConstructor<T> = abstract new (...args: never[]) => T;
+
+const defineOptionalInstanceGuard = <T>(
+  constructor: InstanceConstructor<T> | undefined
+): Guard<T> =>
+  constructor === undefined
+    ? define<T>(() => false)
+    : define<T>((value) => value instanceof constructor);
+
 /**
  * Checks whether a value is a function.
  *
@@ -175,20 +184,18 @@ export const isError = define<Error>(
  *
  * @returns Predicate narrowing to `URL` when supported; otherwise always false.
  */
-export const isURL =
-  typeof URL !== 'undefined'
-    ? define<URL>((value) => value instanceof URL)
-    : define<URL>(() => false);
+export const isURL = defineOptionalInstanceGuard<URL>(
+  typeof URL === 'undefined' ? undefined : URL
+);
 
 /**
  * Checks whether a value is a `Blob` (in environments with Blob available).
  *
  * @returns Predicate narrowing to `Blob` when supported; otherwise always false.
  */
-export const isBlob =
-  typeof Blob !== 'undefined'
-    ? define<Blob>((value) => value instanceof Blob)
-    : define<Blob>(() => false);
+export const isBlob = defineOptionalInstanceGuard<Blob>(
+  typeof Blob === 'undefined' ? undefined : Blob
+);
 
 /**
  * Creates a guard that checks whether a value is an instance of `constructor`.

--- a/src/core/object.ts
+++ b/src/core/object.ts
@@ -13,7 +13,7 @@ import {
   OBJECT_TAG_WEAK_SET
 } from '@/utils/object-tags';
 
-type InstanceConstructor<T> = abstract new (...args: never[]) => T;
+type InstanceConstructor<T> = Function & { readonly prototype: T };
 
 type AnyFunction = (...args: never[]) => unknown;
 

--- a/tests/core/object.test.ts
+++ b/tests/core/object.test.ts
@@ -82,6 +82,36 @@ describe('core/object guards', () => {
     expect(isBlob(b)).toBe(true);
   });
 
+  it('returns false for unavailable platform constructors', () => {
+    const originalURL = Object.getOwnPropertyDescriptor(globalThis, 'URL');
+    const originalBlob = Object.getOwnPropertyDescriptor(globalThis, 'Blob');
+
+    try {
+      Object.defineProperty(globalThis, 'URL', {
+        configurable: true,
+        value: undefined
+      });
+      Object.defineProperty(globalThis, 'Blob', {
+        configurable: true,
+        value: undefined
+      });
+
+      jest.isolateModules(() => {
+        const objectGuards =
+          jest.requireActual<typeof import('@/core/object')>('@/core/object');
+
+        expect(objectGuards.isURL({})).toBe(false);
+        expect(objectGuards.isBlob({})).toBe(false);
+      });
+    } finally {
+      if (originalURL) Object.defineProperty(globalThis, 'URL', originalURL);
+      else Reflect.deleteProperty(globalThis, 'URL');
+
+      if (originalBlob) Object.defineProperty(globalThis, 'Blob', originalBlob);
+      else Reflect.deleteProperty(globalThis, 'Blob');
+    }
+  });
+
   it('creates a guard from a constructor with isInstanceOf', () => {
     class Animal {}
     class Dog extends Animal {}


### PR DESCRIPTION
## Summary

Centralize platform instance guards.

<!-- A brief summary of the changes -->

## Description

- Add a shared internal helper for optional platform-backed instance guards
- Refactor `isURL` and `isBlob` to use the helper
- Add coverage for environments where `URL` or `Blob` constructors are unavailable

<!-- A detailed explanation of the changes, including why they are needed -->
