### PR TITLE
refactor: use isFunction in struct optional field guard

### DIFF
--- a/src/core/combinators/struct.ts
+++ b/src/core/combinators/struct.ts
@@ -5,7 +5,7 @@ import type {
   Predicate
 } from '@/types';
 import { define } from '../define';
-import { isObject, isPlainObject } from '../object';
+import { isFunction, isObject, isPlainObject } from '../object';
 
 type SchemaEntry = readonly [key: string, guard: Predicate<unknown>];
 
@@ -15,7 +15,7 @@ const isOptionalSchemaField = define<OptionalSchemaField<Predicate<unknown>>>(
   (field) =>
     isObject(field) &&
     field.optional === true &&
-    typeof field.guard === 'function'
+    isFunction(field.guard)
 );
 
 const hasRequiredKeys = (


### PR DESCRIPTION
## Summary

Use `isFunction` in struct optional field guard.

<!-- A brief summary of the changes -->

## Description

- Replaced the raw `typeof field.guard === 'function'` check in `struct` with the existing `isFunction` guard.
- Keeps optional schema field detection aligned with the project’s guard abstractions.

<!-- A detailed explanation of the changes, including why they are needed -->
