### PR TITLE
chore: update pnpm v11.2.2

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,7 +76,7 @@ CI runs lint, build, unit tests, and type tests on PRs against `main`.
 
 ## Tips & Notes
 
-- Node: CI uses Node 22 and `pnpm@10.12.4`.
+- Node: CI uses Node 22 and `pnpm@11.2.2`.
 - Public API: prefer adding exports in `src/index.ts`; keep internal helpers unexported.
 - New combinator example: add `src/core/combinators/<name>.ts`, export it in `src/core/combinators/index.ts`, add `tests/<name>.test.ts` and `tests-d/<name>.test-d.ts`.
 - `struct` supports `{ exact?: boolean }` to disallow extra keys when `exact: true`.

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -4,12 +4,12 @@ Welcome! This is the developer guide for is-kit. It keeps things practical and a
 
 ## Quick Start
 
-- Requirements: Node 22, pnpm 10.33.4
+- Requirements: Node 22, pnpm 11.2.2
 - Recommended: use mise to pin tools and run tasks
 
 ```sh
 # Setup toolchain + install deps
-mise install                 # installs Node 22 and pnpm 10.33.4
+mise install                 # installs Node 22 and pnpm 11.2.2
 pnpm install
 
 # Build library and run tests

--- a/README.md
+++ b/README.md
@@ -371,7 +371,7 @@ https://is-kit-docs.vercel.app/
 
 ## 👨‍💻 Development
 
-Requires Node 22 and pnpm 10.33.4.
+Requires Node 22 and pnpm 11.2.2.
 
 - `pnpm lint`
 - `pnpm build`

--- a/docs/mise.toml
+++ b/docs/mise.toml
@@ -10,7 +10,7 @@ NODE_ENV = "development"
 # Tool versions to match local dev and CI
 [tools]
 node = "22"
-pnpm = "10.33.4"
+pnpm = "11.2.2"
 
 [tasks.dev]
 description = "Run dev server"

--- a/mise.toml
+++ b/mise.toml
@@ -10,7 +10,7 @@ NODE_ENV = "development"
 # Tool versions to match local dev and CI
 [tools]
 node = "22"        # CI uses Node 22
-pnpm = "10.33.4"   # From packageManager field
+pnpm = "11.2.2"    # From packageManager field
 
 # Developer tasks (run with: `mise run <task>`)
 [tasks.setup]

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "homepage": "https://github.com/nyaomaru/is-kit#readme",
   "author": "nyaomaru",
   "license": "MIT",
-  "packageManager": "pnpm@10.33.4",
+  "packageManager": "pnpm@11.2.2",
   "devDependencies": {
     "@eslint/js": "^9.33.0",
     "@types/jest": "^30.0.0",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,6 +6,7 @@ packages:
 # exposure to compromised releases before the ecosystem has time to react.
 minimumReleaseAge: 2880
 
-ignoredBuiltDependencies:
-  - esbuild
-  - lefthook
+allowBuilds:
+  esbuild: false
+  lefthook: false
+  unrs-resolver: false


### PR DESCRIPTION
## Summary

<!-- A brief summary of the changes -->

## Description

- Updates documented and configured pnpm version from `10.33.4` to `11.2.2`
- Refreshes workspace build dependency policy from `ignoredBuiltDependencies` to `allowBuilds`
- Explicitly disables builds for `esbuild`, `lefthook`, and `unrs-resolver`

<!-- A detailed explanation of the changes, including why they are needed -->
