### PR TITLE
refactor: consolidate GitHub Actions setup

### DIFF
--- a/.github/actions/setup-project/action.yaml
+++ b/.github/actions/setup-project/action.yaml
@@ -1,0 +1,28 @@
+name: Setup project
+description: Set up mise, restore the pnpm store cache, and install dependencies.
+
+inputs:
+  install-command:
+    description: Command used to install dependencies.
+    required: false
+    default: mise run setup
+
+runs:
+  using: composite
+  steps:
+    - name: Setup mise
+      uses: jdx/mise-action@v3
+      with:
+        install: true
+
+    - name: Cache pnpm store
+      uses: actions/cache@v5
+      with:
+        path: ~/.local/share/pnpm/store
+        key: ${{ runner.os }}-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
+        restore-keys: |
+          ${{ runner.os }}-pnpm-
+
+    - name: Install dependencies
+      shell: bash
+      run: ${{ inputs.install-command }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,18 +11,7 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
-      - name: Setup mise
-        uses: jdx/mise-action@v3
-        with:
-          install: true
-      - name: Cache pnpm store
-        uses: actions/cache@v5
-        with:
-          path: ~/.local/share/pnpm/store
-          key: ${{ runner.os }}-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-
-      - name: Install dependencies
-        run: mise run setup
+      - name: Setup project
+        uses: ./.github/actions/setup-project
       - name: Run build
         run: mise run build

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -11,18 +11,7 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
-      - name: Setup mise
-        uses: jdx/mise-action@v3
-        with:
-          install: true
-      - name: Cache pnpm store
-        uses: actions/cache@v5
-        with:
-          path: ~/.local/share/pnpm/store
-          key: ${{ runner.os }}-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-
-      - name: Install dependencies
-        run: mise run setup
+      - name: Setup project
+        uses: ./.github/actions/setup-project
       - name: Run lint
         run: mise run lint

--- a/.github/workflows/npm-publish.yaml
+++ b/.github/workflows/npm-publish.yaml
@@ -22,21 +22,8 @@ jobs:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
 
-      - name: Setup mise
-        uses: jdx/mise-action@v3
-        with:
-          install: true
-
-      - name: Cache pnpm store
-        uses: actions/cache@v5
-        with:
-          path: ~/.local/share/pnpm/store
-          key: ${{ runner.os }}-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-
-
-      - name: Install dependencies
-        run: mise run setup
+      - name: Setup project
+        uses: ./.github/actions/setup-project
 
       - name: Lint
         run: mise run lint

--- a/.github/workflows/test-types.yaml
+++ b/.github/workflows/test-types.yaml
@@ -11,19 +11,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
-      - name: Setup mise
-        uses: jdx/mise-action@v3
-        with:
-          install: true
-      - name: Cache pnpm store
-        uses: actions/cache@v5
-        with:
-          path: ~/.local/share/pnpm/store
-          key: ${{ runner.os }}-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-
-      - name: Install dependencies
-        run: mise run setup
+      - name: Setup project
+        uses: ./.github/actions/setup-project
       - name: Run build
         run: mise run build
       - name: Run type tests

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,18 +11,7 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
-      - name: Setup mise
-        uses: jdx/mise-action@v3
-        with:
-          install: true
-      - name: Cache pnpm store
-        uses: actions/cache@v5
-        with:
-          path: ~/.local/share/pnpm/store
-          key: ${{ runner.os }}-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-
-      - name: Install dependencies
-        run: mise run setup
+      - name: Setup project
+        uses: ./.github/actions/setup-project
       - name: Run tests
         run: mise run test

--- a/.github/workflows/version-bump.yaml
+++ b/.github/workflows/version-bump.yaml
@@ -27,19 +27,10 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
           persist-credentials: true
-      - name: Setup mise
-        uses: jdx/mise-action@v3
+      - name: Setup project
+        uses: ./.github/actions/setup-project
         with:
-          install: true
-      - name: Cache pnpm store
-        uses: actions/cache@v5
-        with:
-          path: ~/.local/share/pnpm/store
-          key: ${{ runner.os }}-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+          install-command: pnpm install --frozen-lockfile
 
       - name: Generate new version
         id: version


### PR DESCRIPTION
## Summary

Consolidate GitHub Actions setup.

<!-- A brief summary of the changes -->

## Description

- Add a local composite action for shared GitHub Actions project setup.
- Reuse it across lint, build, test, type test, npm publish, and version bump workflows.
- Preserve the version bump workflow’s frozen-lockfile install via a composite action input.

<!-- A detailed explanation of the changes, including why they are needed -->
