### PR TITLE
feat: add typedStruct combinator

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,21 +309,32 @@ if (isAdmin(value)) {
 
 Here are the kinds of problems `is-kit` is especially good at solving:
 
-### API response checks
+### Typed object guard checks
 
 ```ts
-import { isNumber, isString, safeParse, struct } from 'is-kit';
+import { isNumber, isString, optionalKey, safeParse, typedStruct } from 'is-kit';
 
-const isPost = struct({
+type PostResponse = ApiResponse<'/posts/{id}', 'get'>;
+
+const isPost = typedStruct<PostResponse>()({
   id: isNumber,
-  title: isString
+  title: isString,
+  summary: optionalKey(isString)
 });
 
+const payload: unknown = await fetchPost();
 const parsed = safeParse(isPost, payload);
+
 if (parsed.valid) {
   renderPost(parsed.value);
 }
 ```
+
+`typedStruct<T>()` is a small helper for keeping hand-written `struct` guards in
+sync with an existing object type. Optional keys in `T` must still be declared
+with `optionalKey(...)`; this makes drift visible when the target type changes.
+OpenAPI-generated response types are one useful case, but the helper is not an
+OpenAPI validator or schema generator.
 
 ### Safe array filtering
 

--- a/docs/app/api-reference/combinators/typed-struct/page.tsx
+++ b/docs/app/api-reference/combinators/typed-struct/page.tsx
@@ -35,8 +35,13 @@ typedStruct<User>()({
   nickname: optionalKey(isString),
 });
 
-// OpenAPI-generated types are one possible target type.
-type PostResponse = ApiResponse<'/posts/{id}', 'get'>;
+// OpenAPI-generated types can be used the same way.
+type PostResponse = {
+  id: number;
+  title: string;
+  summary?: string;
+};
+
 const isPostResponse = typedStruct<PostResponse>()({
   id: isNumber,
   title: isString,

--- a/docs/app/api-reference/combinators/typed-struct/page.tsx
+++ b/docs/app/api-reference/combinators/typed-struct/page.tsx
@@ -1,0 +1,68 @@
+import { ApiReferencePager } from '@/components/api-reference/pager';
+import { CodeBlock } from '@/components/code/code-block';
+import { Heading } from '@/components/ui/heading';
+import { Paragraph } from '@/components/ui/paragraph';
+import { Stack } from '@/components/ui/stack';
+
+const sample = `import { isNumber, isString, optionalKey, typedStruct } from 'is-kit';
+
+type User = {
+  id: number;
+  name: string;
+  nickname?: string;
+};
+
+const isUser = typedStruct<User>()({
+  id: isNumber,
+  name: isString,
+  nickname: optionalKey(isString),
+});
+
+isUser({ id: 1, name: 'Neko' }); // true
+isUser({ id: 1, name: 'Neko', nickname: 'nya' }); // true
+isUser({ id: 1, name: 'Neko', nickname: 123 }); // false
+
+// typedStruct checks the hand-written struct fields against User.
+typedStruct<User>()({
+  id: isNumber,
+  // TypeScript error: missing name and nickname fields
+});
+
+typedStruct<User>()({
+  id: isNumber,
+  name: isNumber,
+  // TypeScript error: name must use a string guard
+  nickname: optionalKey(isString),
+});
+
+// OpenAPI-generated types are one possible target type.
+type PostResponse = ApiResponse<'/posts/{id}', 'get'>;
+const isPostResponse = typedStruct<PostResponse>()({
+  id: isNumber,
+  title: isString,
+  summary: optionalKey(isString),
+});`;
+
+export default function TypedStructPage() {
+  return (
+    <Stack variant='main' className='container mx-auto px-4 py-10' gap='xl'>
+      <Stack variant='section' gap='md'>
+        <Stack gap='xs'>
+          <Heading variant='h1'>typedStruct</Heading>
+          <Paragraph>
+            Typed wrapper around <code>struct</code> for keeping hand-written
+            object guards in sync with an existing object type.
+          </Paragraph>
+          <Paragraph>
+            Optional keys in the target type must still be declared with{' '}
+            <code>optionalKey(...)</code>. This makes drift visible when the
+            target type changes. This helper is not an OpenAPI validator or a
+            schema generator.
+          </Paragraph>
+        </Stack>
+        <CodeBlock code={sample} language='ts' />
+      </Stack>
+      <ApiReferencePager currentHref='/api-reference/combinators/typed-struct' />
+    </Stack>
+  );
+}

--- a/docs/constants/api-items.ts
+++ b/docs/constants/api-items.ts
@@ -91,6 +91,11 @@ export const API_ITEMS: ApiItem[] = [
     description: 'Shape guard for objects; supports exact key checking.'
   },
   {
+    href: '/api-reference/combinators/typed-struct',
+    title: 'typedStruct',
+    description: 'Typed struct wrapper that checks fields against an existing object type.'
+  },
+  {
     href: '/api-reference/combinators/one-of-values',
     title: 'oneOfValues',
     description: 'Guard literal value sets with exact equality.'

--- a/docs/constants/api-sections.ts
+++ b/docs/constants/api-sections.ts
@@ -27,6 +27,10 @@ export const apiSections: SidebarSection[] = [
       { href: '/api-reference/combinators/record-of', label: 'recordOf' },
       { href: '/api-reference/combinators/struct', label: 'struct' },
       {
+        href: '/api-reference/combinators/typed-struct',
+        label: 'typedStruct'
+      },
+      {
         href: '/api-reference/combinators/one-of-values',
         label: 'oneOfValues'
       }

--- a/package.json
+++ b/package.json
@@ -61,7 +61,11 @@
   "tsd": {
     "directory": "tests-d",
     "compilerOptions": {
-      "baseUrl": "."
+      "baseUrl": ".",
+      "paths": {
+        "@/*": ["src/*"],
+        "is-kit": ["src/index.ts"]
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -61,11 +61,7 @@
   "tsd": {
     "directory": "tests-d",
     "compilerOptions": {
-      "baseUrl": ".",
-      "paths": {
-        "@/*": ["src/*"],
-        "is-kit": ["src/index.ts"]
-      }
+      "baseUrl": "."
     }
   }
 }

--- a/src/core/combinators/index.ts
+++ b/src/core/combinators/index.ts
@@ -5,4 +5,5 @@ export * from './one-of-values';
 export * from './record';
 export * from './set';
 export * from './struct';
+export * from './typed-struct';
 export * from './tuple';

--- a/src/core/combinators/typed-struct.ts
+++ b/src/core/combinators/typed-struct.ts
@@ -6,7 +6,8 @@ type Simplify<T> = { [K in keyof T]: T[K] };
 type StringKeyOf<T> = Extract<keyof T, string>;
 
 type OptionalKeys<T> = {
-  [K in keyof T]-?: object extends Pick<T, K> ? K : never;
+  // WHY: Optional keys accept an empty object when picked in isolation.
+  [K in keyof T]-?: {} extends Pick<T, K> ? K : never;
 }[keyof T];
 
 type RequiredKeys<T> = Exclude<keyof T, OptionalKeys<T>>;

--- a/src/core/combinators/typed-struct.ts
+++ b/src/core/combinators/typed-struct.ts
@@ -1,0 +1,45 @@
+import type { OptionalSchemaField, Predicate, Schema } from '@/types';
+import { struct } from './struct';
+
+type Simplify<T> = { [K in keyof T]: T[K] };
+
+type StringKeyOf<T> = Extract<keyof T, string>;
+
+type OptionalKeys<T> = {
+  [K in keyof T]-?: object extends Pick<T, K> ? K : never;
+}[keyof T];
+
+type RequiredKeys<T> = Exclude<keyof T, OptionalKeys<T>>;
+
+type TypedStructShape<T extends object> = {
+  readonly [K in Extract<RequiredKeys<T>, string>]-?: Predicate<T[K]>;
+} & {
+  readonly [K in Extract<OptionalKeys<T>, string>]-?: OptionalSchemaField<
+    Predicate<T[K]>
+  >;
+};
+
+type NoExtraKeys<S, Shape> = S & {
+  readonly [K in Exclude<keyof S, keyof Shape>]: never;
+};
+
+type TypedStructTarget<T extends object> = Simplify<
+  Readonly<Pick<T, StringKeyOf<T>>>
+>;
+
+/**
+ * Creates a `struct` builder checked against an existing object type.
+ * Optional target keys must also be declared with `optionalKey` so type drift
+ * stays visible when the target type changes.
+ *
+ * @returns Builder that rejects missing, extra, or incompatible struct fields.
+ */
+export function typedStruct<T extends object>() {
+  return <const S extends TypedStructShape<T>>(
+    fields: NoExtraKeys<S, TypedStructShape<T>>,
+    options?: { exact?: boolean }
+  ): Predicate<TypedStructTarget<T>> =>
+    // WHY: `typedStruct` keeps `struct` runtime behavior while using the target
+    // type only to check that hand-written guard fields stay in sync.
+    struct(fields as Schema, options) as Predicate<TypedStructTarget<T>>;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,6 +61,7 @@ export { oneOfValues } from './core/combinators/one-of-values';
 export { recordOf } from './core/combinators/record';
 export { setOf } from './core/combinators/set';
 export { optionalKey, struct } from './core/combinators/struct';
+export { typedStruct } from './core/combinators/typed-struct';
 export { tupleOf } from './core/combinators/tuple';
 
 // Public types

--- a/tests-d/core/combinators/typed-struct.test-d.ts
+++ b/tests-d/core/combinators/typed-struct.test-d.ts
@@ -1,0 +1,102 @@
+import { expectType } from 'tsd';
+import { optionalKey, typedStruct } from '@/core/combinators';
+import { isBoolean, isNumber, isString } from '@/core/primitive';
+import type { Predicate } from '@/types';
+
+type User = {
+  id: string;
+  name: string;
+  age?: number;
+};
+
+type ApiResponse<
+  Path extends string,
+  Method extends string
+> = Path extends '/users/{id}'
+  ? Method extends 'get'
+    ? User
+    : never
+  : never;
+
+type ApiQueryParam<
+  Path extends string,
+  Method extends string
+> = Path extends '/users/{id}'
+  ? Method extends 'get'
+    ? {
+        includePosts?: boolean;
+      }
+    : never
+  : never;
+
+type ApiPathParam<
+  Path extends string,
+  Method extends string
+> = Path extends '/users/{id}'
+  ? Method extends 'get'
+    ? {
+        id: string;
+      }
+    : never
+  : never;
+
+// =============================================
+// describe: typedStruct
+// =============================================
+// it: checks struct fields against a target object type
+const isUser = typedStruct<User>()({
+  id: isString,
+  name: isString,
+  age: optionalKey(isNumber)
+});
+expectType<Predicate<Readonly<User>>>(isUser);
+
+// it: can check hand-written guards against generated API-like types
+type UserResponse = ApiResponse<'/users/{id}', 'get'>;
+const isUserResponse = typedStruct<UserResponse>()({
+  id: isString,
+  name: isString,
+  age: optionalKey(isNumber)
+});
+expectType<Predicate<Readonly<UserResponse>>>(isUserResponse);
+
+const isUserQuery = typedStruct<ApiQueryParam<'/users/{id}', 'get'>>()({
+  includePosts: optionalKey(isBoolean)
+});
+expectType<Predicate<Readonly<{ includePosts?: boolean }>>>(isUserQuery);
+
+const isUserPathParams = typedStruct<ApiPathParam<'/users/{id}', 'get'>>()({
+  id: isString
+});
+expectType<Predicate<Readonly<{ id: string }>>>(isUserPathParams);
+
+// it: rejects missing required keys
+// @ts-expect-error: typedStruct must reject missing required fields.
+typedStruct<User>()({
+  id: isString,
+  age: optionalKey(isNumber)
+});
+
+// it: rejects missing optional keys so type drift stays visible
+// @ts-expect-error: typedStruct must reject omitted optional fields.
+typedStruct<User>()({
+  id: isString,
+  name: isString
+});
+
+// it: rejects incompatible guards
+typedStruct<User>()({
+  id: isString,
+  // @ts-expect-error: typedStruct must reject guards incompatible with the target field.
+  name: isNumber,
+  age: optionalKey(isNumber)
+});
+
+// it: rejects extra struct fields
+typedStruct<User>()({
+  id: isString,
+  name: isString,
+  age: optionalKey(isNumber),
+  // @ts-expect-error: typedStruct must reject fields outside the target type.
+  active: isBoolean
+});

--- a/tests/core/combinators/typed-struct.test.ts
+++ b/tests/core/combinators/typed-struct.test.ts
@@ -1,0 +1,35 @@
+import { optionalKey, typedStruct } from '@/core/combinators';
+import { isNumber, isString } from '@/core/primitive';
+
+describe('typedStruct', () => {
+  type User = {
+    id: string;
+    name: string;
+    age?: number;
+  };
+
+  it('builds a guard through struct semantics', () => {
+    const isUser = typedStruct<User>()({
+      id: isString,
+      name: isString,
+      age: optionalKey(isNumber)
+    });
+
+    expect(isUser({ id: 'u1', name: 'Ada' })).toBe(true);
+    expect(isUser({ id: 'u1', name: 'Ada', age: 36 })).toBe(true);
+    expect(isUser({ id: 'u1', name: 'Ada', age: '36' })).toBe(false);
+  });
+
+  it('uses exact option from struct', () => {
+    const isUser = typedStruct<User>()(
+      {
+        id: isString,
+        name: isString,
+        age: optionalKey(isNumber)
+      },
+      { exact: true }
+    );
+
+    expect(isUser({ id: 'u1', name: 'Ada', extra: true })).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Add `typedStruct` combinator.

<!-- A brief summary of the changes -->

## Description

- Add `typedStruct<T>()` as a typed wrapper around `struct`
- Enforce drift checks for missing, extra, and incompatible struct fields
- Document optional-key behavior and position OpenAPI-generated types as one use case

## Why

`typedStruct<T>()` exists to keep hand-written object guards aligned with an existing TypeScript object type without turning `is-kit` into a schema framework.

`struct(...) is` intentionally small and runtime-first, but it infers a type from the fields you pass. That means a guard can silently drift from a type that already exists elsewhere, such as a domain DTO or an OpenAPI-generated response type.

```ts
type User = {
  id: string;
  name: string;
  age?: number;
};

const isUser = struct({
  id: isString
});
```

This is a valid guard, but it no longer represents User.

`typedStruct<User>()(...)` adds a compile-time check around the same struct runtime behavior. It catches missing fields, extra fields, and incompatible guards while still requiring the developer to write explicit runtime checks.

<!-- A detailed explanation of the changes, including why they are needed -->
