### PR TITLE
refactor: remove typedStruct schema casts

### DIFF
--- a/src/core/combinators/struct.ts
+++ b/src/core/combinators/struct.ts
@@ -1,8 +1,8 @@
 import type {
-  Schema,
   InferSchema,
   OptionalSchemaField,
-  Predicate
+  Predicate,
+  SchemaShape
 } from '@/types';
 import { define } from '../define';
 import { isFunction, isObject, isPlainObject } from '../object';
@@ -61,7 +61,7 @@ export function optionalKey<G extends Predicate<unknown>>(
  * @param options When `{ exact: true }`, disallows properties not in `schema`.
  * @returns Predicate that narrows to the inferred struct type.
  */
-export function struct<S extends Schema>(
+export function struct<const S extends SchemaShape<S>>(
   schema: S,
   options?: { exact?: boolean }
 ): Predicate<InferSchema<S>> {
@@ -71,7 +71,10 @@ export function struct<S extends Schema>(
   const optionalEntries: SchemaEntry[] = [];
   const schemaKeys: string[] = [];
 
-  for (const [key, field] of Object.entries(schema)) {
+  for (const key in schema) {
+    if (!Object.hasOwn(schema, key)) continue;
+
+    const field = schema[key];
     schemaKeys.push(key);
 
     if (isOptionalSchemaField(field)) {

--- a/src/core/combinators/typed-struct.ts
+++ b/src/core/combinators/typed-struct.ts
@@ -1,9 +1,5 @@
-import type { OptionalSchemaField, Predicate, Schema } from '@/types';
+import type { InferSchema, OptionalSchemaField, Predicate } from '@/types';
 import { struct } from './struct';
-
-type Simplify<T> = { [K in keyof T]: T[K] };
-
-type StringKeyOf<T> = Extract<keyof T, string>;
 
 type OptionalKeys<T> = {
   // WHY: Optional keys accept an empty object when picked in isolation.
@@ -24,9 +20,8 @@ type NoExtraKeys<S, Shape> = S & {
   readonly [K in Exclude<keyof S, keyof Shape>]: never;
 };
 
-type TypedStructTarget<T extends object> = Simplify<
-  Readonly<Pick<T, StringKeyOf<T>>>
->;
+type TypedStructFields<T extends object, S extends TypedStructShape<T>> =
+  NoExtraKeys<S, TypedStructShape<T>>;
 
 /**
  * Creates a `struct` builder checked against an existing object type.
@@ -37,10 +32,10 @@ type TypedStructTarget<T extends object> = Simplify<
  */
 export function typedStruct<T extends object>() {
   return <const S extends TypedStructShape<T>>(
-    fields: NoExtraKeys<S, TypedStructShape<T>>,
+    fields: TypedStructFields<T, S>,
     options?: { exact?: boolean }
-  ): Predicate<TypedStructTarget<T>> =>
+  ): Predicate<InferSchema<TypedStructFields<T, S>>> =>
     // WHY: `typedStruct` keeps `struct` runtime behavior while using the target
     // type only to check that hand-written guard fields stay in sync.
-    struct(fields as Schema, options) as Predicate<TypedStructTarget<T>>;
+    struct(fields, options);
 }

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -20,6 +20,13 @@ export type SchemaField =
  */
 export type Schema = Readonly<Record<string, SchemaField>>;
 
+/**
+ * Object schema shape preserving concrete keys.
+ */
+export type SchemaShape<S extends object> = Readonly<{
+  [K in keyof S]: SchemaField;
+}>;
+
 type Simplify<T> = { [K in keyof T]: T[K] };
 
 type InferSchemaField<F> =
@@ -29,13 +36,13 @@ type InferSchemaField<F> =
       ? GuardedOf<G>
       : never;
 
-type RequiredSchemaKeys<S extends Schema> = {
+type RequiredSchemaKeys<S extends SchemaShape<S>> = {
   [K in keyof S]-?: S[K] extends OptionalSchemaField<Predicate<unknown>>
     ? never
     : K;
 }[keyof S];
 
-type OptionalSchemaKeys<S extends Schema> = {
+type OptionalSchemaKeys<S extends SchemaShape<S>> = {
   [K in keyof S]-?: S[K] extends OptionalSchemaField<Predicate<unknown>>
     ? K
     : never;
@@ -44,7 +51,7 @@ type OptionalSchemaKeys<S extends Schema> = {
 /**
  * Infers the readonly object type produced by a `struct` schema.
  */
-export type InferSchema<S extends Schema> = Simplify<
+export type InferSchema<S extends SchemaShape<S>> = Simplify<
   {
     readonly [K in RequiredSchemaKeys<S>]: InferSchemaField<S[K]>;
   } & {


### PR DESCRIPTION
## Summary

Remove typedStruct schema casts.

<!-- A brief summary of the changes -->

## Description

- Remove assertion casts from `typedStruct`
- Add `SchemaShape` to preserve concrete schema keys for `struct`
- Replace `Object.entries` schema iteration with `for...in` + `Object.hasOwn` to keep own-enumerable-key behavior without casts


<!-- A detailed explanation of the changes, including why they are needed -->
