### PR TITLE
test: stabilize struct and typedStruct contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,9 @@ const isConfig = struct({
 
 `optionalKey(guard)` means the property may be missing.
 
-Use `struct(schema, { exact: true })` when extra keys should be rejected.
+Use `struct(schema, { exact: true })` when extra own enumerable string keys
+should be rejected. Exact mode follows `Object.keys(...)` semantics, so symbol
+keys and non-enumerable properties are outside its key matching.
 
 If the property must exist but the value may be `undefined`, use `optional(guard)` instead.
 
@@ -312,7 +314,13 @@ Here are the kinds of problems `is-kit` is especially good at solving:
 ### Typed object guard checks
 
 ```ts
-import { isNumber, isString, optionalKey, safeParse, typedStruct } from 'is-kit';
+import {
+  isNumber,
+  isString,
+  optionalKey,
+  safeParse,
+  typedStruct
+} from 'is-kit';
 
 type PostResponse = ApiResponse<'/posts/{id}', 'get'>;
 

--- a/src/core/combinators/struct.ts
+++ b/src/core/combinators/struct.ts
@@ -58,7 +58,8 @@ export function optionalKey<G extends Predicate<unknown>>(
  * rejects extra keys when `exact: true`.
  *
  * @param schema Record of property guards.
- * @param options When `{ exact: true }`, disallows properties not in `schema`.
+ * @param options When `{ exact: true }`, disallows own enumerable string-key
+ * properties not in `schema`.
  * @returns Predicate that narrows to the inferred struct type.
  */
 export function struct<const S extends SchemaShape<S>>(

--- a/tests-d/core/combinators/typed-struct.test-d.ts
+++ b/tests-d/core/combinators/typed-struct.test-d.ts
@@ -1,5 +1,6 @@
 import { expectType } from 'tsd';
-import { optionalKey, typedStruct } from '@/core/combinators';
+import { arrayOf, optionalKey, typedStruct } from '@/core/combinators';
+import { nullable } from '@/core/nullish';
 import { isBoolean, isNumber, isString } from '@/core/primitive';
 import type { Predicate } from '@/types';
 
@@ -12,11 +13,7 @@ type User = {
 type ApiResponse<
   Path extends string,
   Method extends string
-> = Path extends '/users/{id}'
-  ? Method extends 'get'
-    ? User
-    : never
-  : never;
+> = Path extends '/users/{id}' ? (Method extends 'get' ? User : never) : never;
 
 type ApiQueryParam<
   Path extends string,
@@ -69,6 +66,40 @@ const isUserPathParams = typedStruct<ApiPathParam<'/users/{id}', 'get'>>()({
   id: isString
 });
 expectType<Predicate<Readonly<{ id: string }>>>(isUserPathParams);
+
+// it: supports readonly, nullable, and nested generated API response fields
+type GeneratedUserResponse = {
+  readonly id: string;
+  readonly profile: {
+    readonly displayName: string;
+    readonly bio: string | null;
+  } | null;
+  readonly tags: readonly string[];
+  readonly metadata?: {
+    readonly verified: boolean;
+  } | null;
+};
+
+const isGeneratedProfile = typedStruct<
+  NonNullable<GeneratedUserResponse['profile']>
+>()({
+  displayName: isString,
+  bio: nullable(isString)
+});
+
+const isGeneratedMetadata = typedStruct<
+  NonNullable<GeneratedUserResponse['metadata']>
+>()({
+  verified: isBoolean
+});
+
+const isGeneratedUserResponse = typedStruct<GeneratedUserResponse>()({
+  id: isString,
+  profile: nullable(isGeneratedProfile),
+  tags: arrayOf(isString),
+  metadata: optionalKey(nullable(isGeneratedMetadata))
+});
+expectType<Predicate<Readonly<GeneratedUserResponse>>>(isGeneratedUserResponse);
 
 // it: rejects missing required keys
 // @ts-expect-error: typedStruct must reject missing required fields.

--- a/tests/core/combinators/struct.test.ts
+++ b/tests/core/combinators/struct.test.ts
@@ -49,6 +49,19 @@ describe('struct', () => {
     expect(guard(new Map(entries) as unknown)).toBe(false);
   });
 
+  it('rejects class instances', () => {
+    class User {
+      constructor(
+        readonly id: string,
+        readonly age: number
+      ) {}
+    }
+
+    const guard = struct(schema);
+
+    expect(guard(new User('abc', 20))).toBe(false);
+  });
+
   it('accepts null-prototype objects as plain', () => {
     const guard = struct(schema);
     const o = Object.create(null) as Record<string, unknown>;
@@ -56,6 +69,36 @@ describe('struct', () => {
     o.age = 20;
 
     expect(guard(o)).toBe(true);
+  });
+
+  it('does not use inherited properties to satisfy required keys', () => {
+    const base = Object.create(null) as Record<string, unknown>;
+    base.id = 'abc';
+    const input = Object.create(base) as Record<string, unknown>;
+    input.age = 20;
+
+    const guard = struct(schema);
+
+    expect(guard(input)).toBe(false);
+  });
+
+  it('ignores symbol keys in exact mode', () => {
+    const extra = Symbol('extra');
+    const input = { id: 'abc', age: 20, [extra]: true };
+    const guard = struct(schema, { exact: true });
+
+    expect(guard(input)).toBe(true);
+  });
+
+  it('ignores non-enumerable keys in exact mode', () => {
+    const input = { id: 'abc', age: 20 };
+    Object.defineProperty(input, 'extra', {
+      value: true,
+      enumerable: false
+    });
+    const guard = struct(schema, { exact: true });
+
+    expect(guard(input)).toBe(true);
   });
 
   it('works with nested struct', () => {


### PR DESCRIPTION
## Summary

Stabilize struct and typedStruct contracts.

<!-- A brief summary of the changes -->

## Description

- add `struct` coverage for symbol, non-enumerable, inherited keys, and class instances
- add `typedStruct` type coverage for readonly, nullable, and nested API types
- document exact-mode key semantics

<!-- A detailed explanation of the changes, including why they are needed -->
