### PR TITLE
test: cover Set rejection in struct

### DIFF
--- a/tests/core/combinators/struct.test.ts
+++ b/tests/core/combinators/struct.test.ts
@@ -35,7 +35,7 @@ describe('struct', () => {
     expect(guard({ id: 'abc', age: 20, extra: true })).toBe(false);
   });
 
-  it('rejects non-plain objects (Array/Date/Map) when using isPlainObject', () => {
+  it('rejects non-plain objects (Array/Date/Map/Set) when using isPlainObject', () => {
     const guard = struct(schema);
     const mixed: Array<[string, string] | [string, number]> = [
       ['id', 'abc'],
@@ -47,6 +47,7 @@ describe('struct', () => {
     expect(guard(new Date() as unknown)).toBe(false);
 
     expect(guard(new Map(entries) as unknown)).toBe(false);
+    expect(guard(new Set(['abc', 20]) as unknown)).toBe(false);
   });
 
   it('rejects class instances', () => {


### PR DESCRIPTION
## Summary

Cover Set rejection in `struct`.

<!-- A brief summary of the changes -->

## Description

- add runtime coverage confirming `struct` rejects `Set` instances
- align the test contract with the documented plain-object semantics

<!-- A detailed explanation of the changes, including why they are needed -->
