### PR TITLE
feat: add safeJsonParse

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,7 +264,39 @@ assert(isString, input, 'Expected a string');
 input.toUpperCase();
 ```
 
-### 8. Narrow object keys
+### 8. Decode and validate JSON input
+
+Use `safeJsonParse` at a JSON text boundary. It decodes the text, treats the
+result as `unknown`, and only returns the value after the guard accepts it.
+Invalid JSON and guard mismatches both return `{ valid: false }`; values are not
+coerced to satisfy the guard.
+
+```ts
+import { isString, safeJsonParse, typedStruct } from 'is-kit';
+
+type User = {
+  id: string;
+  name: string;
+};
+
+const isUser = typedStruct<User>()({
+  id: isString,
+  name: isString
+});
+
+declare const input: string;
+const result = safeJsonParse(input, isUser);
+
+if (result.valid) {
+  result.value.name.toUpperCase();
+}
+```
+
+`safeJsonParse` is a decode-then-guard helper. It does not perform schema
+coercion and does not depend on a transport or schema format such as HTTP or
+OpenAPI.
+
+### 9. Narrow object keys
 
 Use key helpers when the important part of a value is one property.
 
@@ -378,7 +410,7 @@ The library is organized around a few small building blocks:
 - **Collections**: `arrayOf`, `nonEmptyArrayOf`, `tupleOf`, `setOf`, `mapOf`, `recordOf`
 - **Literals**: `oneOfValues`, `equals`, `equalsBy`, `equalsKey`
 - **Nullish handling**: `nullable`, `nonNull`, `nullish`, `optional`, `required`
-- **Result helpers**: `safeParse`, `safeParseWith`, `assert`
+- **Result helpers**: `safeParse`, `safeParseWith`, `safeJsonParse`, `assert`
 
 For the full API list and dedicated pages, use the docs site below.
 

--- a/docs/app/api-reference/parse/page.tsx
+++ b/docs/app/api-reference/parse/page.tsx
@@ -4,7 +4,7 @@ import { Heading } from '@/components/ui/heading';
 import { Paragraph } from '@/components/ui/paragraph';
 import { Stack } from '@/components/ui/stack';
 
-const sample = `import { safeParse, safeParseWith, predicateToRefine, and, isString, isNumber } from 'is-kit';
+const sample = `import { safeJsonParse, safeParse, safeParseWith, predicateToRefine, and, typedStruct, isString, isNumber } from 'is-kit';
 
 const parseResult1 = safeParse(isString, 'ok');
 if (parseResult1.valid) {
@@ -14,7 +14,12 @@ if (parseResult1.valid) {
 const isEven = predicateToRefine<number>((num) => num % 2 === 0);
 const isEvenNumber = and(isNumber, isEven);
 const parseEven = safeParseWith(isEvenNumber);
-const parseResult2 = parseEven(4); // { valid: true, value: 4 }`;
+const parseResult2 = parseEven(4); // { valid: true, value: 4 }
+
+type User = { id: string; name: string };
+const isUser = typedStruct<User>()({ id: isString, name: isString });
+const userResult = safeJsonParse('{"id":"1","name":"Ada"}', isUser);
+// JSON is decoded to unknown, then validated without coercion.`;
 
 export default function ParsePage() {
   return (
@@ -23,7 +28,8 @@ export default function ParsePage() {
         <Stack gap='xs'>
           <Heading variant='h1'>parse</Heading>
           <Paragraph>
-            Runtime-safe parsing helpers returning tagged results.
+            Runtime-safe validation helpers returning tagged results.
+            safeJsonParse decodes JSON text to unknown before applying a guard.
           </Paragraph>
         </Stack>
         <CodeBlock code={sample} language='ts' />

--- a/docs/constants/api-items.ts
+++ b/docs/constants/api-items.ts
@@ -21,7 +21,7 @@ export const API_ITEMS: ApiItem[] = [
   {
     href: '/api-reference/parse',
     title: 'parse',
-    description: 'Safe parsing with tagged results.'
+    description: 'Guard values or decode and validate JSON with tagged results.'
   },
   {
     href: '/api-reference/assert',

--- a/docs/constants/docs.ts
+++ b/docs/constants/docs.ts
@@ -55,22 +55,22 @@ const evaluations = ['ok', 'toolong', 123].map((value) => isShortString(value));
 // evaluations: [true, false, false]
 or(isString, isNumber)('x'); // true
 not(isString)(42); // true`,
-  parse: `import { safeParse, struct, isNumber, isString } from 'is-kit';
+  parse: `import { safeJsonParse, struct, isNumber, isString } from 'is-kit';
 
 const isUser = struct({
   id: isNumber,
   name: isString,
 });
 
-const jsonInput = JSON.parse('{"id":1,"name":"neo"}');
-const result = safeParse(isUser, jsonInput);
+const jsonInput = '{"id":1,"name":"neo"}';
+const result = safeJsonParse(jsonInput, isUser);
 // result: ParseResult<{ id: number; name: string }>
 
 if (result.valid) {
   const user = result.value; // { id: number; name: string }
   user.name.toUpperCase(); // 'NEO'
 } else {
-  console.error(result.error.message);
+  console.error('Invalid JSON or user data');
 }`,
   combinators: `import {
   arrayOf,

--- a/src/core/parse.ts
+++ b/src/core/parse.ts
@@ -1,4 +1,4 @@
-import type { Guard, Refine, ParseResult } from '@/types';
+import type { Guard, Predicate, Refine, ParseResult } from '@/types';
 
 /**
  * Executes a guard or refinement and returns a tagged result with the value when valid.
@@ -38,4 +38,28 @@ export function safeParseWith<A, B extends A>(
 ): (value: A) => ParseResult<B>;
 export function safeParseWith(fn: (value: unknown) => boolean) {
   return (value: unknown) => safeParse(fn, value);
+}
+
+/**
+ * Decodes JSON text and validates the decoded value without coercion.
+ *
+ * @param input JSON text to decode.
+ * @param guard Guard used to validate the decoded `unknown` value.
+ * @returns The decoded value when valid; `{ valid: false }` for invalid JSON or a guard mismatch.
+ */
+export function safeJsonParse<T>(
+  input: string,
+  guard: Predicate<T>
+): ParseResult<T> {
+  let value: unknown;
+
+  try {
+    // WHY: JSON.parse returns `any`; contain it as `unknown` at the decode
+    // boundary so callers only receive values that pass the guard.
+    value = JSON.parse(input);
+  } catch {
+    return { valid: false };
+  }
+
+  return safeParse(guard, value);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ export { equals, equalsBy, equalsKey } from './core/equals';
 export { hasKey, hasKeys, narrowKeyTo } from './core/key';
 export { and, andAll, guardIn, not, or } from './core/logic';
 export { nullable, nonNull, nullish, optional, required } from './core/nullish';
-export { safeParse, safeParseWith } from './core/parse';
+export { safeJsonParse, safeParse, safeParseWith } from './core/parse';
 export { predicateToRefine } from './core/predicate';
 
 // Primitive guards

--- a/tests-d/core/parse.test-d.ts
+++ b/tests-d/core/parse.test-d.ts
@@ -1,5 +1,5 @@
 import { expectType } from 'tsd';
-import { safeParse, safeParseWith } from '@/core/parse';
+import { safeJsonParse, safeParse, safeParseWith } from '@/core/parse';
 import type { ParseResult, Refine } from '@/types';
 import { isString } from '@/core/primitive';
 
@@ -47,3 +47,10 @@ const parseBoolean = safeParseWith(isBooleanPredicate);
 expectType<(x: unknown) => ParseResult<boolean>>(parseBoolean);
 const parsedBoolean = parseBoolean(unknownInput);
 expectType<ParseResult<boolean>>(parsedBoolean);
+
+// =============================================
+// describe: safeJsonParse
+// =============================================
+// it: infers ParseResult<T> from the guard
+const jsonStringParseResult = safeJsonParse('"value"', isString);
+expectType<ParseResult<string>>(jsonStringParseResult);

--- a/tests/core/parse.test.ts
+++ b/tests/core/parse.test.ts
@@ -1,6 +1,7 @@
-import { safeParse, safeParseWith } from '@/core/parse';
+import { safeJsonParse, safeParse, safeParseWith } from '@/core/parse';
 import type { Refine } from '@/types';
 import { isString } from '@/core/primitive';
+import { typedStruct } from '@/core/combinators/typed-struct';
 
 describe('safeParse (with Guard)', () => {
   it('returns valid=true and value when guard passes', () => {
@@ -63,5 +64,46 @@ describe('safeParseWith', () => {
 
     expect(parseActive(u1)).toEqual({ valid: true, value: u1 });
     expect(parseActive(u2)).toEqual({ valid: false });
+  });
+});
+
+describe('safeJsonParse', () => {
+  type User = { id: string; name: string };
+  const isUser = typedStruct<User>()({
+    id: isString,
+    name: isString
+  });
+
+  it('returns the decoded value when the guard passes', () => {
+    const result = safeJsonParse('{"id":"1","name":"Ada"}', isUser);
+
+    expect(result).toEqual({
+      valid: true,
+      value: { id: '1', name: 'Ada' }
+    });
+  });
+
+  it('returns valid=false for invalid JSON syntax', () => {
+    expect(safeJsonParse('{"id":', isUser)).toEqual({ valid: false });
+  });
+
+  it('returns valid=false when the decoded value fails the guard', () => {
+    expect(safeJsonParse('{"id":1,"name":"Ada"}', isUser)).toEqual({
+      valid: false
+    });
+  });
+
+  it('does not coerce decoded values', () => {
+    expect(safeJsonParse('1', isString)).toEqual({ valid: false });
+  });
+
+  it('does not catch errors thrown by the guard', () => {
+    const throwingGuard = (_value: unknown): _value is string => {
+      throw new Error('guard failed');
+    };
+
+    expect(() => safeJsonParse('"value"', throwingGuard)).toThrow(
+      'guard failed'
+    );
   });
 });


### PR DESCRIPTION
## Summary

Add `safeJsonParse` 🚀

<!-- A brief summary of the changes -->

## Description

`JSON.parse` returns `any`, which can allow unvalidated values to enter typed code.

`safeJsonParse` provides a type-safe decode-then-guard boundary. It decodes JSON as `unknown` and returns the value only when it passes a user-defined type guard. 👍

- add `safeJsonParse(input, guard)` as a root export
- return `{ valid: false }` for invalid JSON or guard mismatches
- preserve guard error propagation consistently with `safeParse`
- perform no coercion

<!-- A detailed explanation of the changes, including why they are needed -->
