### PR TITLE
fix: enable WHY extraction in changelog workflow

### DIFF
--- a/.github/workflows/update-changelog.yaml
+++ b/.github/workflows/update-changelog.yaml
@@ -16,6 +16,9 @@ jobs:
       changelog_path: CHANGELOG.md
       provider: openai
       release_tag: ${{ github.ref_name }}
+      why: 'true'
+      why_confidence: medium
+      why_label: Why
       dry_run: 'false'
     secrets:
       REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Enable WHY extraction in changelog workflow.

<!-- A brief summary of the changes -->

## Description

- Enable WHY extraction in the changelog workflow.
- Use `medium` confidence.
- Render extracted reasons with the `Why` label.

<!-- A detailed explanation of the changes, including why they are needed -->
