### PR TITLE
feat: add lazy guard for recursive structures

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ This is the core idea of `is-kit`:
 If you are new to the library, these are the pieces to remember:
 
 - `define<T>(fn)` turns a boolean check into a typed guard.
+- `lazy(factory)` defers a guard definition so recursive structures can refer to themselves.
 - `predicateToRefine(fn)` upgrades an existing predicate so it can participate in narrowing chains.
 - `struct({...})` builds an object-shape guard.
 - `safeParse(guard, value)` gives you a small tagged result object.
@@ -224,7 +225,31 @@ import { oneOfValues } from 'is-kit';
 const isStatus = oneOfValues('draft', 'published', 'archived');
 ```
 
-### 6. Handle null and undefined explicitly
+### 6. Validate recursive structures
+
+Use `lazy` when a guard needs to refer to itself. The factory runs on first use,
+and the resulting guard is cached.
+
+```ts
+import { arrayOf, isString, lazy, typedStruct } from 'is-kit';
+import type { Predicate } from 'is-kit';
+
+type Tree = {
+  readonly value: string;
+  readonly children: readonly Tree[];
+};
+
+const isTree: Predicate<Tree> = lazy(() =>
+  typedStruct<Tree>()({
+    value: isString,
+    children: arrayOf(isTree)
+  })
+);
+```
+
+`lazy` does not detect circular references in the input value.
+
+### 7. Handle null and undefined explicitly
 
 Use the nullish helpers to say exactly what is allowed.
 
@@ -245,7 +270,7 @@ const isDefinedString = required(optional(isString));
 const isNonNullString = nonNull(nullable(isString));
 ```
 
-### 7. Parse or assert unknown input
+### 8. Parse or assert unknown input
 
 Use `safeParse` when you want a result object, and `assert` when invalid data should stop execution.
 
@@ -264,7 +289,7 @@ assert(isString, input, 'Expected a string');
 input.toUpperCase();
 ```
 
-### 8. Decode and validate JSON input
+### 9. Decode and validate JSON input
 
 Use `safeJsonParse` at a JSON text boundary. It decodes the text, treats the
 result as `unknown`, and only returns the value after the guard accepts it.
@@ -296,7 +321,7 @@ if (result.valid) {
 coercion and does not depend on a transport or schema format such as HTTP or
 OpenAPI.
 
-### 9. Narrow object keys
+### 10. Narrow object keys
 
 Use key helpers when the important part of a value is one property.
 

--- a/src/core/lazy.ts
+++ b/src/core/lazy.ts
@@ -1,0 +1,21 @@
+import type { Predicate } from '@/types';
+
+/**
+ * Creates a predicate whose implementation is initialized on first use.
+ *
+ * The initialized predicate is cached after the factory returns successfully.
+ * Circular references in the input value are not detected.
+ *
+ * @param factory Function that creates the predicate when it is first evaluated.
+ * @returns Predicate that delegates to the lazily initialized implementation.
+ */
+export function lazy<T>(factory: () => Predicate<T>): Predicate<T> {
+  let predicate: Predicate<T> | undefined;
+
+  return (value: unknown): value is T => {
+    // WHY: Cache only successful initialization so factory errors propagate and
+    // a later evaluation can retry initialization.
+    predicate ??= factory();
+    return predicate(value);
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ export { assert } from './core/assert';
 export { define } from './core/define';
 export { equals, equalsBy, equalsKey } from './core/equals';
 export { hasKey, hasKeys, narrowKeyTo } from './core/key';
+export { lazy } from './core/lazy';
 export { and, andAll, guardIn, not, or } from './core/logic';
 export { nullable, nonNull, nullish, optional, required } from './core/nullish';
 export { safeJsonParse, safeParse, safeParseWith } from './core/parse';

--- a/tests-d/core/lazy.test-d.ts
+++ b/tests-d/core/lazy.test-d.ts
@@ -1,0 +1,23 @@
+import { expectType } from 'tsd';
+import { arrayOf, lazy, typedStruct } from '@/index';
+import { isString } from '@/core/primitive';
+import type { Predicate } from '@/types';
+
+// =============================================
+// describe: lazy
+// =============================================
+// it: preserves the factory predicate type for recursive structures
+type Tree = {
+  readonly value: string;
+  readonly children: readonly Tree[];
+};
+
+const isTree: Predicate<Tree> = lazy(() =>
+  typedStruct<Tree>()({
+    value: isString,
+    children: arrayOf(isTree)
+  })
+);
+
+expectType<Predicate<Tree>>(isTree);
+expectType<Predicate<string>>(lazy(() => isString));

--- a/tests/core/lazy.test.ts
+++ b/tests/core/lazy.test.ts
@@ -1,0 +1,58 @@
+import { arrayOf, typedStruct } from '@/core/combinators';
+import { lazy } from '@/core/lazy';
+import { isString } from '@/core/primitive';
+import type { Predicate } from '@/types';
+
+describe('core/lazy', () => {
+  type Tree = {
+    readonly value: string;
+    readonly children: readonly Tree[];
+  };
+
+  it('validates recursive data structures', () => {
+    const isTree: Predicate<Tree> = lazy(() =>
+      typedStruct<Tree>()({
+        value: isString,
+        children: arrayOf(isTree)
+      })
+    );
+
+    expect(
+      isTree({
+        value: 'root',
+        children: [{ value: 'leaf', children: [] }]
+      })
+    ).toBe(true);
+    expect(
+      isTree({
+        value: 'root',
+        children: [{ value: 1, children: [] }]
+      })
+    ).toBe(false);
+  });
+
+  it('initializes and caches the predicate on first use', () => {
+    const factory = jest.fn(() => isString);
+    const isLazyString = lazy(factory);
+
+    expect(factory).not.toHaveBeenCalled();
+    expect(isLazyString('value')).toBe(true);
+    expect(isLazyString(1)).toBe(false);
+    expect(factory).toHaveBeenCalledTimes(1);
+  });
+
+  it('propagates factory errors and retries initialization', () => {
+    const error = new Error('initialization failed');
+    const factory = jest
+      .fn<() => Predicate<string>>()
+      .mockImplementationOnce(() => {
+        throw error;
+      })
+      .mockReturnValue(isString);
+    const isLazyString = lazy(factory);
+
+    expect(() => isLazyString('value')).toThrow(error);
+    expect(isLazyString('value')).toBe(true);
+    expect(factory).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary

Add a cached lazy guard for safely defining recursive data structures, with runtime and type tests plus documentation,

<!-- A brief summary of the changes -->

## Description

Existing combinators cannot safely initialize self-referencing guards. lazy enables recursive trees and JSON-like structures while preserving is-kit's predicate-only model.

- Lazily initializes the underlying predicate on first evaluation
- Caches successful initialization
- Propagates factory errors and retries on subsequent evaluation

<!-- A detailed explanation of the changes, including why they are needed -->
