### PR TITLE
feat: add isFile guard

### DIFF
--- a/src/core/object.ts
+++ b/src/core/object.ts
@@ -201,6 +201,15 @@ export const isBlob = defineOptionalInstanceGuard<Blob>(
 );
 
 /**
+ * Checks whether a value is a `File` (in environments with File available).
+ *
+ * @returns Predicate narrowing to `File` when supported; otherwise always false.
+ */
+export const isFile = defineOptionalInstanceGuard<File>(
+  typeof File === 'undefined' ? undefined : File
+);
+
+/**
  * Creates a guard that checks whether a value is an instance of `constructor`.
  *
  * @param constructor Constructor used as the right-hand side of `instanceof`.

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,6 +39,7 @@ export {
   isDataView,
   isDate,
   isError,
+  isFile,
   isFunction,
   isInstanceOf,
   isIterable,

--- a/tests-d/core/object.test-d.ts
+++ b/tests-d/core/object.test-d.ts
@@ -20,6 +20,7 @@ import {
   isError,
   isURL,
   isBlob,
+  isFile,
   isInstanceOf
 } from '../../src/core/object';
 
@@ -45,6 +46,7 @@ expectType<Predicate<ArrayBufferView>>(isTypedArray);
 expectType<Predicate<Error>>(isError);
 expectType<Predicate<URL>>(isURL);
 expectType<Predicate<Blob>>(isBlob);
+expectType<Predicate<File>>(isFile);
 
 // =============================================
 // describe: isInstanceOf (types)

--- a/tests/core/object.test.ts
+++ b/tests/core/object.test.ts
@@ -18,6 +18,7 @@ import {
   isError,
   isURL,
   isBlob,
+  isFile,
   isInstanceOf
 } from '@/core/object';
 
@@ -85,18 +86,26 @@ describe('core/object guards', () => {
     expect(isTypedArray(new DataView(new ArrayBuffer(8)))).toBe(false);
   });
 
-  it('detects Error, URL, Blob', () => {
+  it('detects Error, URL, Blob, File', () => {
     expect(isError(new Error('x'))).toBe(true);
     expect(isURL(new URL('https://example.com'))).toBe(true);
 
     // Blob and URL are available in Node 18+
     const b = new Blob(['abc'], { type: 'text/plain' });
     expect(isBlob(b)).toBe(true);
+
+    if (typeof File !== 'undefined') {
+      const f = new File(['abc'], 'example.txt', { type: 'text/plain' });
+      expect(isFile(f)).toBe(true);
+      expect(isBlob(f)).toBe(true);
+      expect(isFile(b)).toBe(false);
+    }
   });
 
   it('returns false for unavailable platform constructors', () => {
     const originalURL = Object.getOwnPropertyDescriptor(globalThis, 'URL');
     const originalBlob = Object.getOwnPropertyDescriptor(globalThis, 'Blob');
+    const originalFile = Object.getOwnPropertyDescriptor(globalThis, 'File');
 
     try {
       Object.defineProperty(globalThis, 'URL', {
@@ -107,6 +116,10 @@ describe('core/object guards', () => {
         configurable: true,
         value: undefined
       });
+      Object.defineProperty(globalThis, 'File', {
+        configurable: true,
+        value: undefined
+      });
 
       jest.isolateModules(() => {
         const objectGuards =
@@ -114,6 +127,7 @@ describe('core/object guards', () => {
 
         expect(objectGuards.isURL({})).toBe(false);
         expect(objectGuards.isBlob({})).toBe(false);
+        expect(objectGuards.isFile({})).toBe(false);
       });
     } finally {
       if (originalURL) Object.defineProperty(globalThis, 'URL', originalURL);
@@ -121,6 +135,9 @@ describe('core/object guards', () => {
 
       if (originalBlob) Object.defineProperty(globalThis, 'Blob', originalBlob);
       else Reflect.deleteProperty(globalThis, 'Blob');
+
+      if (originalFile) Object.defineProperty(globalThis, 'File', originalFile);
+      else Reflect.deleteProperty(globalThis, 'File');
     }
   });
 


### PR DESCRIPTION
## Summary

Add `isFile` guard 🚀

<!-- A brief summary of the changes -->

## Description

- Add `isFile` as a platform guard for `File` objects
- Export `isFile` from the public API
- Add runtime and type tests for `File` detection, unavailable `File` environments, and the `File`/`Blob` relationship

<!-- A detailed explanation of the changes, including why they are needed -->
