### PR TITLE
feat: is-nil

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,17 @@ const isDefinedString = required(optional(isString));
 const isNonNullString = nonNull(nullable(isString));
 ```
 
+For a plain "is it `null` or `undefined`?" check, reach for `isNil` instead of
+hand-rolling `isNull(x) || isUndefined(x)`:
+
+```ts
+import { isNil } from 'is-kit';
+
+isNil(null); // true
+isNil(undefined); // true
+isNil(0); // false
+```
+
 ### 8. Parse or assert unknown input
 
 Use `safeParse` when you want a result object, and `assert` when invalid data should stop execution.
@@ -434,7 +445,7 @@ The library is organized around a few small building blocks:
 - **Object shapes**: `struct`, `optionalKey`, `hasKey`, `hasKeys`, `narrowKeyTo`
 - **Collections**: `arrayOf`, `nonEmptyArrayOf`, `tupleOf`, `setOf`, `mapOf`, `recordOf`
 - **Literals**: `oneOfValues`, `equals`, `equalsBy`, `equalsKey`
-- **Nullish handling**: `nullable`, `nonNull`, `nullish`, `optional`, `required`
+- **Nullish handling**: `isNil`, `nullable`, `nonNull`, `nullish`, `optional`, `required`
 - **Result helpers**: `safeParse`, `safeParseWith`, `safeJsonParse`, `assert`
 
 For the full API list and dedicated pages, use the docs site below.

--- a/docs/app/api-reference/nullish/page.tsx
+++ b/docs/app/api-reference/nullish/page.tsx
@@ -4,7 +4,11 @@ import { Heading } from '@/components/ui/heading';
 import { Paragraph } from '@/components/ui/paragraph';
 import { Stack } from '@/components/ui/stack';
 
-const sample = `import { isString, nullable, nonNull, nullish, optional, required } from 'is-kit';
+const sample = `import { isNil, isString, nullable, nonNull, nullish, optional, required } from 'is-kit';
+
+isNil(null); // true
+isNil(undefined); // true
+isNil(0); // false
 
 const maybeString = nullable(isString);
 maybeString(null); // true
@@ -21,6 +25,8 @@ maybeUndef(undefined); // true
 const needValue = required(optional(isString));
 needValue('ok'); // true
 
+// isNil checks the value itself.
+// nullish(...) widens another guard to accept null or undefined.
 // optional(...) is value-level.
 // For struct key-level optional properties, use optionalKey(...).`;
 
@@ -34,7 +40,9 @@ export default function NullishPage() {
             Nullability helpers to widen or narrow values such as{' '}
             <code>undefined</code> and <code>null</code>. For key-level optional
             fields inside <code>struct</code>, use <code>optionalKey(...)</code>
-            .
+            instead. Use <code className='mx-1'>isNil</code> when you only need
+            to check whether the value itself is <code>null</code> or{' '}
+            <code>undefined</code>.
           </Paragraph>
         </Stack>
         <CodeBlock code={sample} language='ts' />

--- a/docs/app/api-reference/primitive/page.tsx
+++ b/docs/app/api-reference/primitive/page.tsx
@@ -17,6 +17,7 @@ const sample = `import {
   isBoolean,
   isUndefined,
   isNull,
+  isNil,
   isBigInt,
   isSymbol,
   isPrimitive,
@@ -27,6 +28,9 @@ isNumber(123); // true
 isBoolean(false); // true
 isUndefined(undefined); // true
 isNull(null); // true
+isNil(undefined); // true
+isNil(null); // true
+isNil(0); // false
 isBigInt(10n); // true
 isSymbol(Symbol('x')); // true
 
@@ -56,8 +60,9 @@ export default function PrimitivePage() {
             Finite numbers use <code className='mx-1'>isNumber</code> (excludes
             NaN/±Infinity). Use <code className='mx-1'>isPrimitive</code> to
             accept any primitive (string, number, boolean, bigint, symbol,
-            undefined, null). Numeric helpers are available:{' '}
-            <code className='mx-1'>isInteger</code>,
+            undefined, null), and <code className='mx-1'>isNil</code> for a
+            focused <code>null | undefined</code> check. Numeric helpers are
+            available: <code className='mx-1'>isInteger</code>,
             <code className='mx-1'>isSafeInteger</code>,
             <code className='mx-1'>isPositive</code>,
             <code className='mx-1'>isNegative</code>,

--- a/docs/constants/api-items.ts
+++ b/docs/constants/api-items.ts
@@ -31,7 +31,8 @@ export const API_ITEMS: ApiItem[] = [
   {
     href: '/api-reference/nullish',
     title: 'nullish',
-    description: 'Nullability helpers: nullable, optional, required, nonNull.'
+    description:
+      'Nullability helpers: isNil, nullable, optional, required, nonNull.'
   },
   {
     href: '/api-reference/key',
@@ -42,7 +43,7 @@ export const API_ITEMS: ApiItem[] = [
   {
     href: '/api-reference/primitive',
     title: 'primitive',
-    description: 'Primitive guards: string, number, boolean, etc.'
+    description: 'Primitive guards: string, number, boolean, nullish, etc.'
   },
   {
     href: '/api-reference/object',

--- a/src/core/primitive.ts
+++ b/src/core/primitive.ts
@@ -119,6 +119,8 @@ export const isSymbol = define<symbol>((value) => typeof value === 'symbol');
 /**
  * Checks whether a value is exactly `undefined`.
  *
+ * To accept `null` as well, use {@link isNil}.
+ *
  * @returns Predicate narrowing to `undefined`.
  */
 export const isUndefined = define<undefined>((value) => value === undefined);
@@ -126,9 +128,27 @@ export const isUndefined = define<undefined>((value) => value === undefined);
 /**
  * Checks whether a value is exactly `null`.
  *
+ * To accept `undefined` as well, use {@link isNil}.
+ *
  * @returns Predicate narrowing to `null`.
  */
 export const isNull = define<null>((value) => value === null);
+
+/**
+ * Checks whether a value is `null` or `undefined` (nullish).
+ *
+ * Prefer this over hand-rolling `isNull(x) || isUndefined(x)`: it is the same
+ * check expressed once. To widen an existing guard so it also accepts nullish
+ * values, use {@link nullish} instead.
+ *
+ * @returns Predicate narrowing to `null | undefined`.
+ * @example
+ * isNil(null); // true
+ * isNil(undefined); // true
+ * isNil(0); // false
+ * @see or
+ */
+export const isNil = or(isNull, isUndefined);
 
 /**
  * Checks whether a value is a JavaScript primitive.

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ export {
   isInteger,
   isNaN,
   isNegative,
+  isNil,
   isNull,
   isNumber,
   isNumberPrimitive,

--- a/tests-d/core/primitive.test-d.ts
+++ b/tests-d/core/primitive.test-d.ts
@@ -16,6 +16,7 @@ import {
   isSymbol,
   isUndefined,
   isNull,
+  isNil,
   isPrimitive
 } from '../../src/core/primitive';
 import type { Predicate, Refine, Primitive } from '../../src/types';
@@ -56,6 +57,9 @@ expectType<Predicate<bigint>>(isBigInt);
 expectType<Predicate<symbol>>(isSymbol);
 expectType<Predicate<undefined>>(isUndefined);
 expectType<Predicate<null>>(isNull);
+
+// it: isNil narrows to null | undefined
+expectType<Predicate<null | undefined>>(isNil);
 
 // it: isPrimitive is a Predicate<Primitive>
 expectType<Predicate<Primitive>>(isPrimitive);

--- a/tests/core/primitive.test.ts
+++ b/tests/core/primitive.test.ts
@@ -15,6 +15,7 @@ import {
   isSymbol,
   isUndefined,
   isNull,
+  isNil,
   isPrimitive
 } from '../../src/core/primitive';
 
@@ -136,6 +137,17 @@ describe('primitive guards', () => {
   it('isNull', () => {
     expect(isNull(null)).toBe(true);
     expect(isNull(undefined as unknown)).toBe(false);
+  });
+
+  it('isNil', () => {
+    // true cases: null / undefined
+    expect(isNil(null)).toBe(true);
+    expect(isNil(undefined)).toBe(true);
+    // false cases: falsy but present values
+    expect(isNil(0 as unknown)).toBe(false);
+    expect(isNil('' as unknown)).toBe(false);
+    expect(isNil(false as unknown)).toBe(false);
+    expect(isNil(Number.NaN as unknown)).toBe(false);
   });
 
   it('isPrimitive', () => {


### PR DESCRIPTION
## Summary

Add `isNil` 🚀

<!-- A brief summary of the changes -->

## Description

- Add `isNil` as a primitive guard for `null | undefined`
- Export `isNil` from the public entrypoint
- Document when to use `isNil` versus `nullish(guard)`

<!-- A detailed explanation of the changes, including why they are needed -->
