### PR TITLE
docs: guide AI guard composition

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,69 @@ This is the core idea of `is-kit`:
 2. Compose them.
 3. Reuse them anywhere TypeScript narrowing matters.
 
+## 🧭 Guard Composition Guide
+
+When writing reusable guards with `is-kit`, start from the library primitives:
+use `define` for custom runtime checks, and use logic combinators such as
+`and`, `or`, and `not` when combining existing guards. This keeps the result
+reusable as a named guard and preserves the type-level intent in hover,
+completion, and generated declarations.
+
+```ts
+import {
+  and,
+  define,
+  isNil,
+  isNumber,
+  isString,
+  nullish,
+  or,
+  predicateToRefine
+} from 'is-kit';
+
+const isId = or(isString, isNumber);
+const isNullishString = nullish(isString);
+
+const isSlug = define<string>(
+  (value) => isString(value) && /^[a-z0-9-]+$/.test(value)
+);
+
+const isPositiveNumber = and(
+  isNumber,
+  predicateToRefine<number>((value) => value > 0)
+);
+
+isNil(null); // true
+isNil(undefined); // true
+isId('user-1'); // true
+isNullishString(undefined); // true
+isSlug('release-110'); // true
+isPositiveNumber(1); // true
+```
+
+Prefer these forms when generating or reviewing code:
+
+```ts
+declare const value: unknown;
+
+// Prefer
+const isId = or(isString, isNumber);
+const isMaybeName = nullish(isString);
+const isSlug = define<string>(
+  (value) => isString(value) && /^[a-z0-9-]+$/.test(value)
+);
+
+// Avoid
+const isId = (value: unknown) => isString(value) || isNumber(value);
+const isMaybeName = (value: unknown) => value == null || isString(value);
+const isSlug = (value: unknown): value is string =>
+  isString(value) && /^[a-z0-9-]+$/.test(value);
+```
+
+For AI agents or repository-wide conventions, copy
+[docs/agent-rules.md](./docs/agent-rules.md) into the consumer repository's
+agent instructions.
+
 ## ⌚ A 30-second Mental Model
 
 If you are new to the library, these are the pieces to remember:

--- a/docs/agent-rules.md
+++ b/docs/agent-rules.md
@@ -1,0 +1,63 @@
+# is-kit Agent Rules
+
+Copy this into a consumer repository's `AGENTS.md`, `CLAUDE.md`, or
+`.agents/rules/is-kit.md` when AI agents generate or review code that uses
+`is-kit`.
+
+## Usage Rules
+
+- Build reusable custom guards with `define<T>(...)` instead of writing
+  standalone type-predicate functions by hand.
+- Prefer `is-kit` combinators over hand-written boolean composition when
+  combining existing guards.
+- Use `or(isA, isB)` instead of `(value) => isA(value) || isB(value)` when the
+  result should be a reusable guard.
+- Use `and(baseGuard, refinement)` or `andAll(...)` instead of hand-written
+  `&&` checks when narrowing should be preserved.
+- Use `not(guard)` for reusable negated guards.
+- Use `nullable(guard)`, `optional(guard)`, or `nullish(guard)` when widening an
+  existing guard to accept `null` and/or `undefined`.
+- Use `isNil(value)` when checking a value directly for `null | undefined`.
+- Use `optionalKey(guard)` for optional object keys inside `struct`.
+
+## Preferred Examples
+
+```ts
+import {
+  and,
+  define,
+  isNil,
+  isNumber,
+  isString,
+  nullish,
+  or,
+  predicateToRefine
+} from 'is-kit';
+
+const isId = or(isString, isNumber);
+const isMaybeName = nullish(isString);
+const isSlug = define<string>(
+  (value) => isString(value) && /^[a-z0-9-]+$/.test(value)
+);
+const isPositiveNumber = and(
+  isNumber,
+  predicateToRefine<number>((value) => value > 0)
+);
+
+declare const value: unknown;
+
+if (isNil(value)) {
+  return;
+}
+```
+
+## Avoid
+
+```ts
+declare const value: unknown;
+
+const isId = (value: unknown) => isString(value) || isNumber(value);
+const isMaybeName = (value: unknown) => value == null || isString(value);
+const isSlug = (value: unknown): value is string =>
+  isString(value) && /^[a-z0-9-]+$/.test(value);
+```

--- a/docs/app/api-reference/logic/page.tsx
+++ b/docs/app/api-reference/logic/page.tsx
@@ -6,6 +6,12 @@ import { Stack } from '@/components/ui/stack';
 
 const sample = `import { and, or, not, predicateToRefine, isString, isNumber } from 'is-kit';
 
+// Prefer logic combinators over hand-written guardA(x) || guardB(x)
+// when the result should be reusable as a named guard.
+const isId = or(isString, isNumber);
+isId('user-1'); // true
+isId(123); // true
+
 // Clearer name for the min-length rule
 const isLongLiteral = predicateToRefine<string>((value) => value.length > 3);
 
@@ -19,7 +25,6 @@ declare const maybeString: unknown;
 if (isLongString(maybeString)) {
   maybeString.toUpperCase(); // narrowed to string
 }
-or(isString, isNumber)('foo'); // true
 not(isString)(123); // true`;
 
 const sampleAndAll = `import { andAll, predicateToRefine, isString } from 'is-kit';

--- a/docs/app/api-reference/nullish/page.tsx
+++ b/docs/app/api-reference/nullish/page.tsx
@@ -9,6 +9,7 @@ const sample = `import { isNil, isString, nullable, nonNull, nullish, optional, 
 isNil(null); // true
 isNil(undefined); // true
 isNil(0); // false
+// isNil checks a value directly for null | undefined.
 
 const maybeString = nullable(isString);
 maybeString(null); // true
@@ -18,6 +19,7 @@ notNull('x'); // true
 
 const maybe = nullish(isString);
 maybe(undefined); // true
+// nullish(isString) widens isString to also accept null or undefined.
 
 const maybeUndef = optional(isString);
 maybeUndef(undefined); // true

--- a/jsr.json
+++ b/jsr.json
@@ -8,6 +8,7 @@
   "publish": {
     "include": [
       "src",
+      "docs/agent-rules.md",
       "README.md",
       "LICENSE"
     ]

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   ],
   "files": [
     "dist",
+    "docs/agent-rules.md",
     "README.md",
     "LICENSE"
   ],

--- a/src/core/define.ts
+++ b/src/core/define.ts
@@ -2,12 +2,18 @@ import type { Predicate } from '@/types';
 
 /**
  * Wraps a user function as a typed predicate.
+ * Prefer `define<T>(...)` when creating a reusable custom guard from a runtime
+ * boolean check.
  *
  * Note: The correctness of the predicate is the caller's responsibility.
  * Its result is coerced to a boolean using `!!` for consistent guard behavior.
  *
  * @param fn Function that returns truthy when the value matches the target shape.
  * @returns Predicate narrowing to the intended type when it returns true.
+ * @example
+ * const isSlug = define<string>(
+ *   (value) => isString(value) && /^[a-z0-9-]+$/.test(value)
+ * );
  */
 export function define<T>(fn: (value: unknown) => value is T): Predicate<T>;
 export function define<T>(fn: (value: unknown) => boolean): Predicate<T>;

--- a/src/core/logic.ts
+++ b/src/core/logic.ts
@@ -11,10 +11,18 @@ import { toBooleanPredicates } from '@/utils';
 
 /**
  * Combines a precondition guard with an additional refinement to narrow the type.
+ * Prefer this over hand-written `precondition(x) && condition(x)` when the
+ * composed predicate should be reused as a guard.
  *
  * @param precondition Broad guard evaluated first; short-circuits on failure.
  * @param condition Refinement evaluated only when `precondition` passes.
  * @returns Predicate that narrows the input to a subtype.
+ * @example
+ * const isPositiveNumber = and(
+ *   isNumber,
+ *   predicateToRefine<number>((value) => value > 0)
+ * );
+ * @see andAll
  */
 export function and<A, B extends A>(
   precondition: Guard<A>,
@@ -30,10 +38,15 @@ export function and<A, B extends A>(
 
 /**
  * Chains a sequence of refinements after a precondition, returning the final guard type.
+ * Use this instead of nested `&&` checks when each step should keep narrowing
+ * the next refinement.
  *
  * @param precondition Initial guard applied first.
  * @param steps Subsequent refinements applied in order.
  * @returns Guard reflecting the result of the refinement chain.
+ * @example
+ * const isPublicTitle = andAll(isString, minLength(4), startsWithPublic);
+ * @see and
  */
 export function andAll<A>(precondition: Guard<A>): Guard<A>;
 export function andAll<A, B extends A>(
@@ -57,9 +70,14 @@ export function andAll<A, Chain extends readonly Refine<unknown, unknown>[]>(
 
 /**
  * Logical OR over multiple guards.
+ * Prefer this over hand-written `guardA(x) || guardB(x)` when the composed
+ * predicate should be reused as a guard.
  *
  * @param guards Guards to evaluate; passes if any guard passes.
  * @returns Guard for the union of all guarded types.
+ * @example
+ * const isId = or(isString, isNumber);
+ * @see oneOf
  */
 export function or<P extends readonly Guard<unknown>[]>(
   ...guards: P
@@ -74,6 +92,7 @@ export function or<P extends readonly Guard<unknown>[]>(
  * Adapts a guard so it can be used as a refinement within a known supertype.
  *
  * @returns Function that converts a `Guard<T>` into a `Refine<A, T>` when `T extends A`.
+ * @see and
  */
 export function guardIn<A>(): <T extends A>(guard: Guard<T>) => Refine<A, T>;
 export function guardIn<A>(): <T extends A>(guard: Guard<T>) => Refine<A, T> {
@@ -84,9 +103,12 @@ export function guardIn<A>(): <T extends A>(guard: Guard<T>) => Refine<A, T> {
 
 /**
  * Logical negation of a guard/refinement.
+ * Use this when a negated predicate should be named and reused.
  *
  * @param guard Guard or refinement to negate.
  * @returns Refinement excluding the guarded subtype from the input type.
+ * @example
+ * const isPresent = not(isNil);
  */
 export function not<A, T>(
   guard: Guard<T>

--- a/src/core/nullish.ts
+++ b/src/core/nullish.ts
@@ -18,9 +18,14 @@ const requireWhen =
 
 /**
  * Allows `null` in addition to values accepted by the given guard/refinement.
+ * Use this instead of hand-writing `value === null || guard(value)` when the
+ * widened predicate should stay reusable.
  *
  * @param guard Guard/refinement for the base type.
  * @returns Guard/refinement widened to include `null`.
+ * @example
+ * const isNullableString = nullable(isString);
+ * @see nullish
  */
 export function nullable<T>(guard: Guard<T>): Guard<T | null>;
 export function nullable<A, B extends A>(
@@ -35,6 +40,8 @@ export function nullable(fn: (value: unknown) => boolean) {
  *
  * @param guard Guard/refinement possibly including `null`.
  * @returns Guard/refinement with `null` excluded.
+ * @example
+ * const isNonNullString = nonNull(nullable(isString));
  */
 export function nonNull<T>(guard: Guard<T>): Guard<Exclude<T, null>>;
 export function nonNull<A, B extends A>(
@@ -46,9 +53,14 @@ export function nonNull(fn: (value: unknown) => boolean) {
 
 /**
  * Allows `null` or `undefined` in addition to values accepted by the guard.
+ * Use this instead of hand-writing `isNil(value) || guard(value)` when widening
+ * another guard.
  *
  * @param guard Guard/refinement for the base type.
  * @returns Guard/refinement widened to include `null | undefined`.
+ * @example
+ * const isNullishString = nullish(isString);
+ * @see isNil
  */
 export function nullish<T>(guard: Guard<T>): Guard<T | null | undefined>;
 export function nullish<A, B extends A>(
@@ -60,9 +72,13 @@ export function nullish(fn: (value: unknown) => boolean) {
 
 /**
  * Allows `undefined` in addition to values accepted by the guard.
+ * Use this for value-level optionality. For optional object keys in `struct`,
+ * use `optionalKey(...)`.
  *
  * @param guard Guard/refinement for the base type.
  * @returns Guard/refinement widened to include `undefined`.
+ * @example
+ * const isOptionalString = optional(isString);
  */
 export function optional<T>(guard: Guard<T>): Guard<T | undefined>;
 export function optional<A, B extends A>(
@@ -77,6 +93,8 @@ export function optional(fn: (value: unknown) => boolean) {
  *
  * @param guard Guard/refinement that may accept `undefined`.
  * @returns Guard/refinement with `undefined` removed.
+ * @example
+ * const isRequiredString = required(optional(isString));
  */
 export function required<T>(guard: Guard<T | undefined>): Guard<T>;
 export function required<A, B extends A>(

--- a/src/core/primitive.ts
+++ b/src/core/primitive.ts
@@ -119,18 +119,22 @@ export const isSymbol = define<symbol>((value) => typeof value === 'symbol');
 /**
  * Checks whether a value is exactly `undefined`.
  *
- * To accept `null` as well, use {@link isNil}.
+ * For reusable nullish checks, use {@link isNil} or compose a named guard with
+ * {@link or} once and reuse it.
  *
  * @returns Predicate narrowing to `undefined`.
+ * @see isNil
  */
 export const isUndefined = define<undefined>((value) => value === undefined);
 
 /**
  * Checks whether a value is exactly `null`.
  *
- * To accept `undefined` as well, use {@link isNil}.
+ * For reusable nullish checks, use {@link isNil} or compose a named guard with
+ * {@link or} once and reuse it.
  *
  * @returns Predicate narrowing to `null`.
+ * @see isNil
  */
 export const isNull = define<null>((value) => value === null);
 

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,9 +1,22 @@
 import { defineConfig } from 'tsup';
 
+// WHY: tsup's declaration bundling drops entry-file comments, so the AI-facing
+// guide must be attached as a dts banner to appear at the top of dist/index.d.ts.
+const dtsBanner = `/**
+ * is-kit guard authoring guide:
+ * - Use define<T>(...) for reusable custom runtime checks.
+ * - Use and, andAll, or, and not to compose existing guards instead of
+ *   hand-written boolean wrappers.
+ * - Use nullable, optional, or nullish to widen guards for nullish values.
+ * - Use struct or typedStruct for object-shape guards.
+ */`;
+
 export default defineConfig({
   entry: ['src/index.ts'],
   format: ['esm', 'cjs'],
-  dts: true,
+  dts: {
+    banner: dtsBanner
+  },
   clean: true,
   outDir: 'dist',
   target: 'esnext'


### PR DESCRIPTION
## Summary

Guide AI guard composition.

<!-- A brief summary of the changes -->

## Description

- Add AI-facing guard composition guidance to README and docs examples.
- Add a consumer-repo agent rules snippet for using `define` and logic combinators.
- Add a declaration banner so `dist/index.d.ts` starts with guard authoring guidance.

<!-- A detailed explanation of the changes, including why they are needed -->
