### PR TITLE
refactor: centralize own property checks

### DIFF
--- a/src/core/combinators/struct.ts
+++ b/src/core/combinators/struct.ts
@@ -4,6 +4,7 @@ import type {
   Predicate,
   SchemaShape
 } from '@/types';
+import { hasOwnPropertyKey } from '@/utils/own-properties';
 import { define } from '../define';
 import { isFunction, isObject, isPlainObject } from '../object';
 
@@ -22,7 +23,7 @@ const hasRequiredKeys = (
 ): boolean =>
   // WHY: Required fields must be own properties; inherited values should not
   // satisfy a schema because `struct` models object payload shape, not prototype chains.
-  entries.every(([key, guard]) => Object.hasOwn(obj, key) && guard(obj[key]));
+  entries.every(([key, guard]) => hasOwnPropertyKey(obj, key) && guard(obj[key]));
 
 const hasValidOptionalKeys = (
   obj: Record<string, unknown>,
@@ -30,7 +31,9 @@ const hasValidOptionalKeys = (
 ): boolean =>
   // WHY: Optional keys are validated only when present. Missing keys stay valid
   // without forcing callers to encode `undefined` into the value guard.
-  entries.every(([key, guard]) => !Object.hasOwn(obj, key) || guard(obj[key]));
+  entries.every(
+    ([key, guard]) => !hasOwnPropertyKey(obj, key) || guard(obj[key])
+  );
 
 const hasOnlyAllowedKeys = (
   obj: Record<string, unknown>,
@@ -73,7 +76,7 @@ export function struct<const S extends SchemaShape<S>>(
   const schemaKeys: string[] = [];
 
   for (const key in schema) {
-    if (!Object.hasOwn(schema, key)) continue;
+    if (!hasOwnPropertyKey(schema, key)) continue;
 
     const field = schema[key];
     schemaKeys.push(key);

--- a/src/core/equals.ts
+++ b/src/core/equals.ts
@@ -1,4 +1,5 @@
 import type { GuardedOf, Predicate } from '@/types';
+import { hasOwnPropertyKey } from '@/utils/own-properties';
 import { define } from './define';
 import { isObject } from './object';
 
@@ -71,7 +72,7 @@ export function equalsKey<K extends PropertyKey, const T>(
   const hasMatchingKey = define<Record<K, T>>((input) => {
     return (
       isObject(input) &&
-      Object.hasOwn(input, key) &&
+      hasOwnPropertyKey(input, key) &&
       Object.is(input[key], target)
     );
   });

--- a/src/core/key.ts
+++ b/src/core/key.ts
@@ -1,4 +1,5 @@
 import type { Guard, GuardedOf, Predicate } from '@/types';
+import { hasOwnPropertyKey, hasOwnPropertyKeys } from '@/utils/own-properties';
 import { equalsKey } from './equals';
 import { define } from './define';
 import { isObject } from './object';
@@ -11,7 +12,7 @@ import { isObject } from './object';
  */
 export const hasKey = <K extends PropertyKey>(key: K) =>
   define<Record<K, unknown>>((input) =>
-    isObject(input) && Object.hasOwn(input, key));
+    isObject(input) && hasOwnPropertyKey(input, key));
 
 /**
  * Checks whether a value has all specified own keys.
@@ -31,7 +32,7 @@ export const hasKeys = <
   }
 
   return define<Record<KS[number], unknown>>(
-    (input) => isObject(input) && keys.every((key) => Object.hasOwn(input, key))
+    (input) => isObject(input) && hasOwnPropertyKeys(input, keys)
   );
 };
 

--- a/src/utils/own-properties.ts
+++ b/src/utils/own-properties.ts
@@ -1,0 +1,28 @@
+// WHY: Keep this as a low-level binary helper instead of wrapping it with
+// `define`. `define` builds unary public guards, while core modules call this
+// after they already narrowed the value and still need to pass a dynamic key.
+// Importing `define` here would also make utils depend on core.
+
+/**
+ * Checks whether an object has an own property key.
+ *
+ * @param value Object-like value already narrowed by callers.
+ * @param key Property key to check.
+ * @returns Whether `key` is present directly on `value`.
+ */
+export const hasOwnPropertyKey = <K extends PropertyKey>(
+  value: Record<PropertyKey, unknown>,
+  key: K
+): value is Record<K, unknown> => Object.hasOwn(value, key);
+
+/**
+ * Checks whether an object has every requested own property key.
+ *
+ * @param value Object-like value already narrowed by callers.
+ * @param keys Property keys to check.
+ * @returns Whether all keys are present directly on `value`.
+ */
+export const hasOwnPropertyKeys = (
+  value: Record<PropertyKey, unknown>,
+  keys: readonly PropertyKey[]
+): boolean => keys.every((key) => hasOwnPropertyKey(value, key));


### PR DESCRIPTION
## Summary

Centralize own property checks.

<!-- A brief summary of the changes -->

## Description

- Add internal own-property helpers for shared `Object.hasOwn` semantics.
- Reuse the helpers in `hasKey`, `hasKeys`, `equalsKey`, and `struct`.
- Keep the helper internal and avoid changing the public API surface.

<!-- A detailed explanation of the changes, including why they are needed -->
