### PR TITLE
refactor: expose typed struct schema types

### DIFF
--- a/src/core/combinators/typed-struct.ts
+++ b/src/core/combinators/typed-struct.ts
@@ -1,27 +1,10 @@
-import type { InferSchema, OptionalSchemaField, Predicate } from '@/types';
+import type {
+  InferSchema,
+  Predicate,
+  TypedStructFields,
+  TypedStructShape
+} from '@/types';
 import { struct } from './struct';
-
-type OptionalKeys<T> = {
-  // WHY: Optional keys accept an empty object when picked in isolation.
-  [K in keyof T]-?: {} extends Pick<T, K> ? K : never;
-}[keyof T];
-
-type RequiredKeys<T> = Exclude<keyof T, OptionalKeys<T>>;
-
-type TypedStructShape<T extends object> = {
-  readonly [K in Extract<RequiredKeys<T>, string>]-?: Predicate<T[K]>;
-} & {
-  readonly [K in Extract<OptionalKeys<T>, string>]-?: OptionalSchemaField<
-    Predicate<T[K]>
-  >;
-};
-
-type NoExtraKeys<S, Shape> = S & {
-  readonly [K in Exclude<keyof S, keyof Shape>]: never;
-};
-
-type TypedStructFields<T extends object, S extends TypedStructShape<T>> =
-  NoExtraKeys<S, TypedStructShape<T>>;
 
 /**
  * Creates a `struct` builder checked against an existing object type.

--- a/src/index.ts
+++ b/src/index.ts
@@ -83,9 +83,14 @@ export type {
 export type { Primitive } from './types/primitive';
 export type {
   InferSchema,
+  NoExtraKeys,
+  OptionalObjectKeys,
   OptionalSchemaField,
+  RequiredObjectKeys,
   Schema,
-  SchemaField
+  SchemaField,
+  TypedStructFields,
+  TypedStructShape
 } from './types/schema';
 
 // Utility helpers

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -58,3 +58,42 @@ export type InferSchema<S extends SchemaShape<S>> = Simplify<
     readonly [K in OptionalSchemaKeys<S>]?: InferSchemaField<S[K]>;
   }
 >;
+
+/**
+ * Extracts optional keys from an object type.
+ */
+export type OptionalObjectKeys<T> = {
+  // WHY: Optional keys accept an empty object when picked in isolation.
+  [K in keyof T]-?: {} extends Pick<T, K> ? K : never;
+}[keyof T];
+
+/**
+ * Extracts required keys from an object type.
+ */
+export type RequiredObjectKeys<T> = Exclude<keyof T, OptionalObjectKeys<T>>;
+
+/**
+ * Schema shape checked against an existing object type by `typedStruct`.
+ */
+export type TypedStructShape<T extends object> = {
+  readonly [K in Extract<RequiredObjectKeys<T>, string>]-?: Predicate<T[K]>;
+} & {
+  readonly [K in Extract<OptionalObjectKeys<T>, string>]-?: OptionalSchemaField<
+    Predicate<T[K]>
+  >;
+};
+
+/**
+ * Keeps a schema type while rejecting keys outside the expected shape.
+ */
+export type NoExtraKeys<S, Shape> = S & {
+  readonly [K in Exclude<keyof S, keyof Shape>]: never;
+};
+
+/**
+ * Field set accepted by `typedStruct` for a target object type.
+ */
+export type TypedStructFields<
+  T extends object,
+  S extends TypedStructShape<T>
+> = NoExtraKeys<S, TypedStructShape<T>>;

--- a/tests-d/core/combinators/typed-struct.test-d.ts
+++ b/tests-d/core/combinators/typed-struct.test-d.ts
@@ -1,8 +1,15 @@
-import { expectType } from 'tsd';
+import { expectAssignable, expectType } from 'tsd';
 import { arrayOf, optionalKey, typedStruct } from '@/core/combinators';
 import { nullable } from '@/core/nullish';
 import { isBoolean, isNumber, isString } from '@/core/primitive';
 import type { Predicate } from '@/types';
+import type {
+  NoExtraKeys,
+  OptionalObjectKeys,
+  RequiredObjectKeys,
+  TypedStructFields,
+  TypedStructShape
+} from 'is-kit';
 
 type User = {
   id: string;
@@ -100,6 +107,31 @@ const isGeneratedUserResponse = typedStruct<GeneratedUserResponse>()({
   metadata: optionalKey(nullable(isGeneratedMetadata))
 });
 expectType<Predicate<Readonly<GeneratedUserResponse>>>(isGeneratedUserResponse);
+
+// =============================================
+// describe: public type exports
+// =============================================
+// it: exposes typedStruct schema helper types from the package entrypoint
+type PublicUserShape = TypedStructShape<User>;
+type PublicUserFields = TypedStructFields<User, PublicUserShape>;
+type PublicUserRequiredKeys = RequiredObjectKeys<User>;
+type PublicUserOptionalKeys = OptionalObjectKeys<User>;
+type PublicUserNoExtraKeys = NoExtraKeys<{ id: string }, { id: unknown }>;
+
+expectAssignable<PublicUserShape>({
+  id: isString,
+  name: isString,
+  age: optionalKey(isNumber)
+});
+expectAssignable<PublicUserFields>({
+  id: isString,
+  name: isString,
+  age: optionalKey(isNumber)
+});
+expectAssignable<PublicUserRequiredKeys>('id');
+expectAssignable<PublicUserRequiredKeys>('name');
+expectType<PublicUserOptionalKeys>('age');
+expectAssignable<PublicUserNoExtraKeys>({ id: 'user-1' });
 
 // it: rejects missing required keys
 // @ts-expect-error: typedStruct must reject missing required fields.


### PR DESCRIPTION
## Summary

Expose typed struct schema types.

<!-- A brief summary of the changes -->

## Description

- Move `typedStruct` helper types into `src/types/schema.ts`
- Export reusable object key and typed struct schema utility types
- Update `typed-struct` to import the shared public types instead of defining them locally

<!-- A detailed explanation of the changes, including why they are needed -->
