### PR TITLE
feat: export shared struct options type

### DIFF
--- a/src/core/combinators/struct.ts
+++ b/src/core/combinators/struct.ts
@@ -2,7 +2,8 @@ import type {
   InferSchema,
   OptionalSchemaField,
   Predicate,
-  SchemaShape
+  SchemaShape,
+  StructOptions
 } from '@/types';
 import { hasOwnPropertyKey } from '@/utils/own-properties';
 import { define } from '../define';
@@ -23,7 +24,9 @@ const hasRequiredKeys = (
 ): boolean =>
   // WHY: Required fields must be own properties; inherited values should not
   // satisfy a schema because `struct` models object payload shape, not prototype chains.
-  entries.every(([key, guard]) => hasOwnPropertyKey(obj, key) && guard(obj[key]));
+  entries.every(
+    ([key, guard]) => hasOwnPropertyKey(obj, key) && guard(obj[key])
+  );
 
 const hasValidOptionalKeys = (
   obj: Record<string, unknown>,
@@ -67,7 +70,7 @@ export function optionalKey<G extends Predicate<unknown>>(
  */
 export function struct<const S extends SchemaShape<S>>(
   schema: S,
-  options?: { exact?: boolean }
+  options?: StructOptions
 ): Predicate<InferSchema<S>> {
   // WHY: Split required and optional fields once per builder so each
   // invocation only performs property lookups and guard calls.

--- a/src/core/combinators/typed-struct.ts
+++ b/src/core/combinators/typed-struct.ts
@@ -1,6 +1,7 @@
 import type {
   InferSchema,
   Predicate,
+  StructOptions,
   TypedStructFields,
   TypedStructShape
 } from '@/types';
@@ -11,12 +12,15 @@ import { struct } from './struct';
  * Optional target keys must also be declared with `optionalKey` so type drift
  * stays visible when the target type changes.
  *
+ * Target-compatible field guards may narrow further than the target field type;
+ * the returned predicate preserves those narrower inferred types.
+ *
  * @returns Builder that rejects missing, extra, or incompatible struct fields.
  */
 export function typedStruct<T extends object>() {
   return <const S extends TypedStructShape<T>>(
     fields: TypedStructFields<T, S>,
-    options?: { exact?: boolean }
+    options?: StructOptions
   ): Predicate<InferSchema<TypedStructFields<T, S>>> =>
     // WHY: `typedStruct` keeps `struct` runtime behavior while using the target
     // type only to check that hand-written guard fields stay in sync.

--- a/src/index.ts
+++ b/src/index.ts
@@ -89,6 +89,7 @@ export type {
   RequiredObjectKeys,
   Schema,
   SchemaField,
+  StructOptions,
   TypedStructFields,
   TypedStructShape
 } from './types/schema';

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -21,6 +21,14 @@ export type SchemaField =
 export type Schema = Readonly<Record<string, SchemaField>>;
 
 /**
+ * Configures object-key validation for `struct` and `typedStruct`.
+ */
+export type StructOptions = Readonly<{
+  /** Rejects extra own enumerable string-key properties when enabled. */
+  exact?: boolean;
+}>;
+
+/**
  * Object schema shape preserving concrete keys.
  */
 export type SchemaShape<S extends object> = Readonly<{

--- a/tests-d/core/combinators/typed-struct.test-d.ts
+++ b/tests-d/core/combinators/typed-struct.test-d.ts
@@ -1,5 +1,10 @@
 import { expectAssignable, expectType } from 'tsd';
-import { arrayOf, optionalKey, typedStruct } from '@/core/combinators';
+import {
+  arrayOf,
+  oneOfValues,
+  optionalKey,
+  typedStruct
+} from '@/core/combinators';
 import { nullable } from '@/core/nullish';
 import { isBoolean, isNumber, isString } from '@/core/primitive';
 import type { Predicate } from '@/types';
@@ -7,13 +12,17 @@ import type {
   NoExtraKeys,
   OptionalObjectKeys,
   RequiredObjectKeys,
+  StructOptions,
   TypedStructFields,
   TypedStructShape
 } from 'is-kit';
 
 type User = {
+  /** Stable identifier returned for the user. */
   id: string;
+  /** Display name shown for the user. */
   name: string;
+  /** Optional age supplied by the user profile. */
   age?: number;
 };
 
@@ -28,6 +37,7 @@ type ApiQueryParam<
 > = Path extends '/users/{id}'
   ? Method extends 'get'
     ? {
+        /** Whether related posts should be included in the response. */
         includePosts?: boolean;
       }
     : never
@@ -39,6 +49,7 @@ type ApiPathParam<
 > = Path extends '/users/{id}'
   ? Method extends 'get'
     ? {
+        /** User identifier extracted from the request path. */
         id: string;
       }
     : never
@@ -76,13 +87,20 @@ expectType<Predicate<Readonly<{ id: string }>>>(isUserPathParams);
 
 // it: supports readonly, nullable, and nested generated API response fields
 type GeneratedUserResponse = {
+  /** Stable identifier returned by the generated API client. */
   readonly id: string;
+  /** Nullable public profile associated with the user. */
   readonly profile: {
+    /** Name rendered in public profile views. */
     readonly displayName: string;
+    /** Optional profile biography represented as a nullable value. */
     readonly bio: string | null;
   } | null;
+  /** Immutable labels attached to the user. */
   readonly tags: readonly string[];
+  /** Optional nullable metadata returned for privileged requests. */
   readonly metadata?: {
+    /** Whether the user passed the verification process. */
     readonly verified: boolean;
   } | null;
 };
@@ -108,6 +126,26 @@ const isGeneratedUserResponse = typedStruct<GeneratedUserResponse>()({
 });
 expectType<Predicate<Readonly<GeneratedUserResponse>>>(isGeneratedUserResponse);
 
+// it: preserves field guards that narrow beyond the target field types
+type Content = {
+  /** Discriminator identifying the content representation. */
+  kind: string;
+  /** Content payload before a guard narrows its representation. */
+  value: string | number;
+  /** Optional label before a guard narrows its representation. */
+  label?: string | number;
+};
+
+const isTextContent = typedStruct<Content>()({
+  kind: oneOfValues('text'),
+  value: isString,
+  label: optionalKey(isString)
+});
+expectType<
+  Predicate<Readonly<{ kind: 'text'; value: string; label?: string }>>
+>(isTextContent);
+expectAssignable<Predicate<Readonly<Content>>>(isTextContent);
+
 // =============================================
 // describe: public type exports
 // =============================================
@@ -117,6 +155,7 @@ type PublicUserFields = TypedStructFields<User, PublicUserShape>;
 type PublicUserRequiredKeys = RequiredObjectKeys<User>;
 type PublicUserOptionalKeys = OptionalObjectKeys<User>;
 type PublicUserNoExtraKeys = NoExtraKeys<{ id: string }, { id: unknown }>;
+const publicStructOptions: StructOptions = { exact: true };
 
 expectAssignable<PublicUserShape>({
   id: isString,
@@ -132,6 +171,16 @@ expectAssignable<PublicUserRequiredKeys>('id');
 expectAssignable<PublicUserRequiredKeys>('name');
 expectType<PublicUserOptionalKeys>('age');
 expectAssignable<PublicUserNoExtraKeys>({ id: 'user-1' });
+expectType<StructOptions>(publicStructOptions);
+
+typedStruct<User>()(
+  {
+    id: isString,
+    name: isString,
+    age: optionalKey(isNumber)
+  },
+  publicStructOptions
+);
 
 // it: rejects missing required keys
 // @ts-expect-error: typedStruct must reject missing required fields.


### PR DESCRIPTION
## Summary

Export shared struct options type.

<!-- A brief summary of the changes -->

## Description

- add and publicly export a readonly `StructOptions` type
- use the shared options type for `struct` and `typedStruct`
- document and test that `typedStruct` preserves field-level narrowing

<!-- A detailed explanation of the changes, including why they are needed -->
