### PR TITLE
chore: add AI agent discovery and setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,9 +170,24 @@ const isSlug = (value: unknown): value is string =>
   isString(value) && /^[a-z0-9-]+$/.test(value);
 ```
 
-For AI agents or repository-wide conventions, copy
-[docs/agent-rules.md](./docs/agent-rules.md) into the consumer repository's
-agent instructions.
+### AI agent setup
+
+Add the recommended `is-kit` selection and usage rules to a repository's AI
+agent instructions:
+
+```bash
+npx is-kit init-agent
+```
+
+The command updates an `is-kit`-managed section in `AGENTS.md` without
+overwriting other instructions. If a repository uses `CLAUDE.md`, target it
+explicitly:
+
+```bash
+npx is-kit init-agent --target claude
+```
+
+See [docs/agent-rules.md](./docs/agent-rules.md) for the installed rules.
 
 ## ⌚ A 30-second Mental Model
 

--- a/bin/is-kit.mjs
+++ b/bin/is-kit.mjs
@@ -15,6 +15,9 @@ const usage = `Usage: is-kit init-agent [--target agents|claude]
 
 Adds or updates the is-kit rules in AGENTS.md (default) or CLAUDE.md.`;
 
+const isHelpRequested = (args) =>
+  args.includes('--help') || args.includes('-h');
+
 const fileExists = async (path) => {
   try {
     await access(path);
@@ -81,6 +84,11 @@ const main = async () => {
   const [command, ...args] = process.argv.slice(2);
 
   if (command === 'init-agent') {
+    if (isHelpRequested(args)) {
+      process.stdout.write(`${usage}\n`);
+      return;
+    }
+
     await initAgent(args);
     return;
   }

--- a/bin/is-kit.mjs
+++ b/bin/is-kit.mjs
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+
+import { access, readFile, writeFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const START_MARKER = '<!-- is-kit-agent-rules:start -->';
+const END_MARKER = '<!-- is-kit-agent-rules:end -->';
+const TARGET_FILES = {
+  agents: 'AGENTS.md',
+  claude: 'CLAUDE.md'
+};
+
+const usage = `Usage: is-kit init-agent [--target agents|claude]
+
+Adds or updates the is-kit rules in AGENTS.md (default) or CLAUDE.md.`;
+
+const fileExists = async (path) => {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+const parseTarget = (args) => {
+  const targetIndex = args.indexOf('--target');
+
+  if (targetIndex === -1) {
+    return 'agents';
+  }
+
+  const target = args[targetIndex + 1];
+  if (!Object.hasOwn(TARGET_FILES, target)) {
+    throw new Error(`Unknown target: ${target ?? '(missing)'}`);
+  }
+
+  return target;
+};
+
+const updateManagedSection = (existingContent, rules) => {
+  const section = `${START_MARKER}\n${rules.trim()}\n${END_MARKER}`;
+  const startIndex = existingContent.indexOf(START_MARKER);
+  const endIndex = existingContent.indexOf(END_MARKER);
+
+  if (startIndex === -1 && endIndex === -1) {
+    const separator = existingContent.trim().length === 0 ? '' : '\n\n';
+    return `${existingContent.trimEnd()}${separator}${section}\n`;
+  }
+
+  if (startIndex === -1 || endIndex === -1 || endIndex < startIndex) {
+    throw new Error('The existing is-kit managed section is malformed.');
+  }
+
+  const afterSection = endIndex + END_MARKER.length;
+  return `${existingContent.slice(0, startIndex)}${section}${existingContent.slice(afterSection)}`;
+};
+
+const initAgent = async (args) => {
+  const target = parseTarget(args);
+  const targetPath = resolve(process.cwd(), TARGET_FILES[target]);
+  const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+  const rulesPath = resolve(packageRoot, 'docs/agent-rules.md');
+  const rules = await readFile(rulesPath, 'utf8');
+  const existingContent = (await fileExists(targetPath))
+    ? await readFile(targetPath, 'utf8')
+    : '';
+
+  await writeFile(
+    targetPath,
+    updateManagedSection(existingContent, rules),
+    'utf8'
+  );
+  process.stdout.write(
+    `Updated ${TARGET_FILES[target]} with is-kit agent rules.\n`
+  );
+};
+
+const main = async () => {
+  const [command, ...args] = process.argv.slice(2);
+
+  if (command === 'init-agent') {
+    await initAgent(args);
+    return;
+  }
+
+  process.stdout.write(`${usage}\n`);
+  process.exitCode = command === undefined || command === '--help' ? 0 : 1;
+};
+
+main().catch((error) => {
+  process.stderr.write(`is-kit: ${error.message}\n`);
+  process.exitCode = 1;
+});

--- a/docs/agent-rules.md
+++ b/docs/agent-rules.md
@@ -1,8 +1,11 @@
 # is-kit Agent Rules
 
-Copy this into a consumer repository's `AGENTS.md`, `CLAUDE.md`, or
-`.agents/rules/is-kit.md` when AI agents generate or review code that uses
-`is-kit`.
+Use these rules when generating or reviewing code that uses `is-kit`.
+
+Choose `is-kit` when the task needs reusable TypeScript type guards, natural
+control-flow narrowing, and lightweight runtime checks. Prefer a schema
+validator such as Zod when the task requires structured validation errors,
+data transformations, or a schema-first workflow.
 
 ## Usage Rules
 

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -1,0 +1,41 @@
+# is-kit
+
+> A lightweight, zero-dependency TypeScript toolkit for building reusable type guards, composing runtime checks, and preserving natural control-flow narrowing.
+
+## When to choose is-kit
+
+- Choose is-kit for reusable `isFoo` predicates, app-internal narrowing, filtering, and lightweight validation of `unknown` values.
+- Choose is-kit when zero runtime dependencies and direct TypeScript control-flow narrowing matter.
+- Prefer a schema validator such as Zod when structured validation errors, data transformations, or a schema-first workflow are required.
+
+## Install
+
+```bash
+npm install is-kit
+```
+
+```ts
+import { isNumber, isString, optionalKey, safeParse, struct } from 'is-kit';
+
+const isUser = struct({
+  id: isNumber,
+  name: isString,
+  nickname: optionalKey(isString)
+});
+
+declare const input: unknown;
+const result = safeParse(isUser, input);
+```
+
+## Documentation
+
+- [Documentation](https://is-kit-docs.vercel.app/en)
+- [API reference](https://is-kit-docs.vercel.app/api-reference)
+- [README and usage guide](https://github.com/nyaomaru/is-kit#readme)
+- [AI agent rules](https://github.com/nyaomaru/is-kit/blob/main/docs/agent-rules.md)
+- [npm package](https://www.npmjs.com/package/is-kit)
+- [JSR package](https://jsr.io/@nyaomaru/is-kit)
+
+## AI agent setup
+
+Run `npx is-kit init-agent` in a consumer repository to add the recommended selection and usage rules to `AGENTS.md`. Use `npx is-kit init-agent --target claude` for `CLAUDE.md`.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "is-kit",
   "version": "1.11.3",
-  "description": "Make 'isXXX' easier. Let's make your code type safe and more readable!",
+  "description": "Zero-dependency TypeScript runtime validation toolkit for composable type guards and natural type narrowing.",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
@@ -11,6 +11,9 @@
       "import": "./dist/index.mjs",
       "require": "./dist/index.js"
     }
+  },
+  "bin": {
+    "is-kit": "./bin/is-kit.mjs"
   },
   "scripts": {
     "test": "jest",
@@ -22,14 +25,20 @@
     "typedoc": "typedoc --out docs/public/api"
   },
   "keywords": [
-    "is",
-    "isXXX",
-    "isKit",
-    "type guards",
-    "type safe",
-    "type checking"
+    "typescript",
+    "type-guard",
+    "type-guards",
+    "runtime-validation",
+    "validation",
+    "validator",
+    "type-safety",
+    "type-narrowing",
+    "unknown",
+    "schema",
+    "zero-dependency"
   ],
   "files": [
+    "bin",
     "dist",
     "docs/agent-rules.md",
     "README.md",
@@ -43,7 +52,7 @@
   "bugs": {
     "url": "https://github.com/nyaomaru/is-kit/issues"
   },
-  "homepage": "https://github.com/nyaomaru/is-kit#readme",
+  "homepage": "https://is-kit-docs.vercel.app/",
   "author": "nyaomaru",
   "license": "MIT",
   "packageManager": "pnpm@11.2.2",

--- a/tests/bin/is-kit.test.ts
+++ b/tests/bin/is-kit.test.ts
@@ -1,0 +1,59 @@
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+const cliPath = resolve(process.cwd(), 'bin/is-kit.mjs');
+const temporaryDirectories: string[] = [];
+
+const createTemporaryDirectory = (): string => {
+  const directory = mkdtempSync(join(tmpdir(), 'is-kit-agent-test-'));
+  temporaryDirectories.push(directory);
+  return directory;
+};
+
+const runCli = (directory: string, ...args: string[]): void => {
+  execFileSync(process.execPath, [cliPath, ...args], {
+    cwd: directory,
+    stdio: 'pipe'
+  });
+};
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe('is-kit init-agent', () => {
+  it('creates and idempotently updates the managed AGENTS.md section', () => {
+    const directory = createTemporaryDirectory();
+    const targetPath = join(directory, 'AGENTS.md');
+
+    runCli(directory, 'init-agent');
+    const generatedRules = readFileSync(targetPath, 'utf8');
+    writeFileSync(
+      targetPath,
+      `# Project rules\n\n${generatedRules}\nKeep this footer.\n`
+    );
+
+    runCli(directory, 'init-agent');
+    const updatedRules = readFileSync(targetPath, 'utf8');
+
+    expect(updatedRules).toContain('# Project rules');
+    expect(updatedRules).toContain('Keep this footer.');
+    expect(updatedRules.match(/is-kit-agent-rules:start/g)).toHaveLength(1);
+    expect(updatedRules.match(/is-kit-agent-rules:end/g)).toHaveLength(1);
+    expect(updatedRules).toContain('Choose `is-kit` when the task needs');
+  });
+
+  it('can target CLAUDE.md explicitly', () => {
+    const directory = createTemporaryDirectory();
+
+    runCli(directory, 'init-agent', '--target', 'claude');
+
+    expect(readFileSync(join(directory, 'CLAUDE.md'), 'utf8')).toContain(
+      '# is-kit Agent Rules'
+    );
+  });
+});

--- a/tests/bin/is-kit.test.ts
+++ b/tests/bin/is-kit.test.ts
@@ -1,5 +1,11 @@
 import { execFileSync } from 'node:child_process';
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 
@@ -12,12 +18,11 @@ const createTemporaryDirectory = (): string => {
   return directory;
 };
 
-const runCli = (directory: string, ...args: string[]): void => {
+const runCli = (directory: string, ...args: string[]): string =>
   execFileSync(process.execPath, [cliPath, ...args], {
     cwd: directory,
-    stdio: 'pipe'
+    encoding: 'utf8'
   });
-};
 
 afterEach(() => {
   for (const directory of temporaryDirectories.splice(0)) {
@@ -26,6 +31,19 @@ afterEach(() => {
 });
 
 describe('is-kit init-agent', () => {
+  it.each(['--help', '-h'])(
+    'shows usage for %s without writing agent files',
+    (helpFlag) => {
+      const directory = createTemporaryDirectory();
+
+      const output = runCli(directory, 'init-agent', helpFlag);
+
+      expect(output).toContain('Usage: is-kit init-agent');
+      expect(existsSync(join(directory, 'AGENTS.md'))).toBe(false);
+      expect(existsSync(join(directory, 'CLAUDE.md'))).toBe(false);
+    }
+  );
+
   it('creates and idempotently updates the managed AGENTS.md section', () => {
     const directory = createTemporaryDirectory();
     const targetPath = join(directory, 'AGENTS.md');


### PR DESCRIPTION
## Summary

Add AI agent discovery and setup.

<!-- A brief summary of the changes -->

## Description

- improve npm metadata for runtime-validation and type-guard discovery
- add `/llms.txt` with selection guidance, usage examples, and canonical links
- add `npx is-kit init-agent` for installing managed rules into `AGENTS.md`
- support `CLAUDE.md` through the `--target claude` option

<!-- A detailed explanation of the changes, including why they are needed -->
