### PR TITLE
fix: use latest package for agent setup commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ Add the recommended `is-kit` selection and usage rules to a repository's AI
 agent instructions:
 
 ```bash
-npx is-kit init-agent
+npx --yes is-kit@latest init-agent
 ```
 
 The command updates an `is-kit`-managed section in `AGENTS.md` without
@@ -184,7 +184,7 @@ overwriting other instructions. If a repository uses `CLAUDE.md`, target it
 explicitly:
 
 ```bash
-npx is-kit init-agent --target claude
+npx --yes is-kit@latest init-agent --target claude
 ```
 
 See [docs/agent-rules.md](./docs/agent-rules.md) for the installed rules.

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -38,4 +38,4 @@ const result = safeParse(isUser, input);
 
 ## AI agent setup
 
-Run `npx is-kit init-agent` in a consumer repository to add the recommended selection and usage rules to `AGENTS.md`. Use `npx is-kit init-agent --target claude` for `CLAUDE.md`.
+Run `npx --yes is-kit@latest init-agent` in a consumer repository to add the recommended selection and usage rules to `AGENTS.md`. Use `npx --yes is-kit@latest init-agent --target claude` for `CLAUDE.md`.


### PR DESCRIPTION
## Summary

Use latest package for agent setup commands.

<!-- A brief summary of the changes -->

## Description

- explicitly run `is-kit@latest` in AI agent setup commands
- prevent `npx` from resolving an older local `is-kit` version without the CLI

<!-- A detailed explanation of the changes, including why they are needed -->
