### PR TITLE
fix: use intrinsic brand checks for built-ins

### DIFF
--- a/src/core/combinators/map.ts
+++ b/src/core/combinators/map.ts
@@ -1,6 +1,6 @@
 import type { GuardedOf, Predicate } from '@/types';
 import { define } from '../define';
-import { everyMapEntry } from '@/utils';
+import { everyBrandedMapEntry } from '@/utils';
 import { isMap } from '../object';
 
 /**
@@ -18,6 +18,6 @@ export function mapOf<
   valueGuard: VF
 ): Predicate<ReadonlyMap<GuardedOf<KF>, GuardedOf<VF>>> {
   return define<ReadonlyMap<GuardedOf<KF>, GuardedOf<VF>>>(
-    (input) => isMap(input) && everyMapEntry(input, keyGuard, valueGuard)
+    (input) => isMap(input) && everyBrandedMapEntry(input, keyGuard, valueGuard)
   );
 }

--- a/src/core/combinators/set.ts
+++ b/src/core/combinators/set.ts
@@ -1,6 +1,6 @@
 import type { GuardedOf, Predicate } from '@/types';
 import { define } from '../define';
-import { everySetValue } from '@/utils';
+import { everyBrandedSetValue } from '@/utils';
 import { isSet } from '../object';
 
 /**
@@ -13,6 +13,6 @@ export function setOf<VF extends Predicate<unknown>>(
   valueGuard: VF
 ): Predicate<ReadonlySet<GuardedOf<VF>>> {
   return define<ReadonlySet<GuardedOf<VF>>>(
-    (input) => isSet(input) && everySetValue(input, valueGuard)
+    (input) => isSet(input) && everyBrandedSetValue(input, valueGuard)
   );
 }

--- a/src/core/object.ts
+++ b/src/core/object.ts
@@ -53,7 +53,7 @@ const arrayBufferByteLength = getIntrinsicGetter(
   ArrayBuffer.prototype,
   'byteLength'
 );
-const dataViewByteLength = getIntrinsicGetter(DataView.prototype, 'byteLength');
+const dataViewBuffer = getIntrinsicGetter(DataView.prototype, 'buffer');
 
 const defineOptionalInstanceGuard = <T>(
   constructor: InstanceCheckTarget<T> | undefined
@@ -206,7 +206,7 @@ export const isArrayBuffer = defineIntrinsicBrandGuard<ArrayBuffer>((value) =>
  * @returns Predicate narrowing to `DataView`.
  */
 export const isDataView = defineIntrinsicBrandGuard<DataView>((value) =>
-  dataViewByteLength.call(value)
+  dataViewBuffer.call(value)
 );
 
 /**

--- a/src/core/object.ts
+++ b/src/core/object.ts
@@ -1,17 +1,6 @@
 import { define } from './define';
 import type { Guard } from '@/types';
-import {
-  getTag,
-  OBJECT_TAG_ARRAY_BUFFER,
-  OBJECT_TAG_DATA_VIEW,
-  OBJECT_TAG_DATE,
-  OBJECT_TAG_ERROR,
-  OBJECT_TAG_MAP,
-  OBJECT_TAG_REGEXP,
-  OBJECT_TAG_SET,
-  OBJECT_TAG_WEAK_MAP,
-  OBJECT_TAG_WEAK_SET
-} from '@/utils';
+import { getTag, OBJECT_TAG_ERROR } from '@/utils';
 
 // WHY: DOM constructors such as URL and Blob are declared as constructor
 // objects with a prototype, not as the full Function interface. The helper
@@ -21,8 +10,50 @@ type InstanceCheckTarget<T> = { readonly prototype: T };
 
 type AnyFunction = (...args: never[]) => unknown;
 
-const defineTagGuard = <T>(tag: string): Guard<T> =>
-  define<T>((value) => getTag(value) === tag);
+const BUILTIN_BRAND_SENTINEL = Object.freeze({});
+
+// WHY: Calling captured built-in intrinsics verifies internal slots. Unlike
+// object tags, this rejects Symbol.toStringTag spoofing while still accepting
+// cross-realm instances and subclasses.
+const getIntrinsicGetter = (
+  prototype: object,
+  key: PropertyKey
+): (() => unknown) => {
+  const getter = Object.getOwnPropertyDescriptor(prototype, key)?.get;
+
+  // WHY: Standard built-in accessors should always exist. Keeping the fallback
+  // callable lets the exported guard remain total in a non-conforming runtime.
+  return (
+    getter ??
+    (() => {
+      throw new TypeError(`Missing intrinsic getter: ${String(key)}`);
+    })
+  );
+};
+
+const defineIntrinsicBrandGuard = <T>(
+  checkBrand: (value: unknown) => unknown
+): Guard<T> =>
+  define<T>((value) => {
+    try {
+      checkBrand(value);
+      return true;
+    } catch {
+      return false;
+    }
+  });
+
+const dateGetTime = Date.prototype.getTime;
+const mapHas = Map.prototype.has;
+const setHas = Set.prototype.has;
+const weakMapHas = WeakMap.prototype.has;
+const weakSetHas = WeakSet.prototype.has;
+const regExpSource = getIntrinsicGetter(RegExp.prototype, 'source');
+const arrayBufferByteLength = getIntrinsicGetter(
+  ArrayBuffer.prototype,
+  'byteLength'
+);
+const dataViewByteLength = getIntrinsicGetter(DataView.prototype, 'byteLength');
 
 const defineOptionalInstanceGuard = <T>(
   constructor: InstanceCheckTarget<T> | undefined
@@ -80,47 +111,58 @@ export const isArray = define<readonly unknown[]>(Array.isArray);
  *
  * @returns Predicate narrowing to `Date`.
  */
-export const isDate = define<Date>(
-  (value) =>
-    getTag(value) === OBJECT_TAG_DATE &&
-    !Number.isNaN((value as Date).getTime())
-);
+export const isDate = define<Date>((value) => {
+  try {
+    return !Number.isNaN(dateGetTime.call(value));
+  } catch {
+    return false;
+  }
+});
 
 /**
  * Checks whether a value is a `RegExp`.
  *
  * @returns Predicate narrowing to `RegExp`.
  */
-export const isRegExp = defineTagGuard<RegExp>(OBJECT_TAG_REGEXP);
+export const isRegExp = defineIntrinsicBrandGuard<RegExp>((value) =>
+  regExpSource.call(value)
+);
 
 /**
  * Checks whether a value is a `Map`.
  *
  * @returns Predicate narrowing to `Map<unknown, unknown>`.
  */
-export const isMap = defineTagGuard<Map<unknown, unknown>>(OBJECT_TAG_MAP);
+export const isMap = defineIntrinsicBrandGuard<Map<unknown, unknown>>((value) =>
+  mapHas.call(value, BUILTIN_BRAND_SENTINEL)
+);
 
 /**
  * Checks whether a value is a `Set`.
  *
  * @returns Predicate narrowing to `Set<unknown>`.
  */
-export const isSet = defineTagGuard<Set<unknown>>(OBJECT_TAG_SET);
+export const isSet = defineIntrinsicBrandGuard<Set<unknown>>((value) =>
+  setHas.call(value, BUILTIN_BRAND_SENTINEL)
+);
 
 /**
  * Checks whether a value is a `WeakMap`.
  *
  * @returns Predicate narrowing to `WeakMap<object, unknown>`.
  */
-export const isWeakMap =
-  defineTagGuard<WeakMap<object, unknown>>(OBJECT_TAG_WEAK_MAP);
+export const isWeakMap = defineIntrinsicBrandGuard<WeakMap<object, unknown>>(
+  (value) => weakMapHas.call(value, BUILTIN_BRAND_SENTINEL)
+);
 
 /**
  * Checks whether a value is a `WeakSet`.
  *
  * @returns Predicate narrowing to `WeakSet<object>`.
  */
-export const isWeakSet = defineTagGuard<WeakSet<object>>(OBJECT_TAG_WEAK_SET);
+export const isWeakSet = defineIntrinsicBrandGuard<WeakSet<object>>((value) =>
+  weakSetHas.call(value, BUILTIN_BRAND_SENTINEL)
+);
 
 /**
  * Checks whether a value is promise-like (has a `then` function).
@@ -154,15 +196,18 @@ export const isAsyncIterable = define<AsyncIterable<unknown>>((value) =>
  *
  * @returns Predicate narrowing to `ArrayBuffer`.
  */
-export const isArrayBuffer =
-  defineTagGuard<ArrayBuffer>(OBJECT_TAG_ARRAY_BUFFER);
+export const isArrayBuffer = defineIntrinsicBrandGuard<ArrayBuffer>((value) =>
+  arrayBufferByteLength.call(value)
+);
 
 /**
  * Checks whether a value is a `DataView`.
  *
  * @returns Predicate narrowing to `DataView`.
  */
-export const isDataView = defineTagGuard<DataView>(OBJECT_TAG_DATA_VIEW);
+export const isDataView = defineIntrinsicBrandGuard<DataView>((value) =>
+  dataViewByteLength.call(value)
+);
 
 /**
  * Checks whether a value is a typed array view (any `ArrayBufferView` except DataView).
@@ -170,7 +215,7 @@ export const isDataView = defineTagGuard<DataView>(OBJECT_TAG_DATA_VIEW);
  * @returns Predicate narrowing to `ArrayBufferView`.
  */
 export const isTypedArray = define<ArrayBufferView>(
-  (value) => ArrayBuffer.isView(value) && getTag(value) !== OBJECT_TAG_DATA_VIEW
+  (value) => ArrayBuffer.isView(value) && !isDataView(value)
 );
 
 /**

--- a/src/utils/guard-collections.ts
+++ b/src/utils/guard-collections.ts
@@ -1,5 +1,8 @@
 type BooleanPredicate<T> = (value: T) => boolean;
 
+const mapEntries = Map.prototype.entries;
+const setValues = Set.prototype.values;
+
 const everyIterableValue = <T>(
   values: Iterable<T>,
   predicate: BooleanPredicate<T>
@@ -66,6 +69,15 @@ export const everySetValue = (
 ): boolean => everyIterableValue(values, predicate);
 
 /**
+ * Checks built-in Set data without invoking an instance-provided iterator.
+ * WHY: A branded Set subclass may override its public iterator and throw.
+ */
+export const everyBrandedSetValue = (
+  values: ReadonlySet<unknown>,
+  predicate: BooleanPredicate<unknown>
+): boolean => everyIterableValue(setValues.call(values), predicate);
+
+/**
  * Checks whether every map entry satisfies the provided key and value predicates.
  *
  * @param values Map values to validate.
@@ -80,6 +92,20 @@ export const everyMapEntry = (
 ): boolean =>
   everyKeyValueEntry(
     values,
+    (key, value) => keyPredicate(key) && valuePredicate(value)
+  );
+
+/**
+ * Checks built-in Map data without invoking an instance-provided iterator.
+ * WHY: A branded Map subclass may override its public iterator and throw.
+ */
+export const everyBrandedMapEntry = (
+  values: ReadonlyMap<unknown, unknown>,
+  keyPredicate: BooleanPredicate<unknown>,
+  valuePredicate: BooleanPredicate<unknown>
+): boolean =>
+  everyKeyValueEntry(
+    mapEntries.call(values),
     (key, value) => keyPredicate(key) && valuePredicate(value)
   );
 

--- a/tests/core/combinators/map.test.ts
+++ b/tests/core/combinators/map.test.ts
@@ -53,6 +53,9 @@ describe('mapOf (runtime)', () => {
 
   it('rejects non-map inputs', () => {
     expect(isStringNumberMap({ a: 1 } as unknown)).toBe(false);
+    expect(isStringNumberMap({ [Symbol.toStringTag]: 'Map' } as unknown)).toBe(
+      false
+    );
     expect(isStringNumberMap(new Set([['a', 1]]) as unknown)).toBe(false);
     expect(isStringNumberMap(null as unknown)).toBe(false);
     expect(isStringNumberMap(undefined as unknown)).toBe(false);
@@ -80,5 +83,17 @@ describe('mapOf (runtime)', () => {
     ).toBe(false);
 
     expect(isNested('nope' as unknown)).toBe(false);
+  });
+
+  it('uses the intrinsic iterator for branded maps', () => {
+    const map = new Map<string, number>([['a', 1]]);
+    Object.defineProperty(map, Symbol.iterator, {
+      value: () => {
+        throw new Error('custom iterator should not run');
+      }
+    });
+
+    expect(() => isStringNumberMap(map)).not.toThrow();
+    expect(isStringNumberMap(map)).toBe(true);
   });
 });

--- a/tests/core/combinators/set.test.ts
+++ b/tests/core/combinators/set.test.ts
@@ -21,6 +21,7 @@ describe('setOf (runtime)', () => {
 
   it('rejects non-set inputs', () => {
     expect(isStringSet(['a', 'b'] as unknown)).toBe(false);
+    expect(isStringSet({ [Symbol.toStringTag]: 'Set' } as unknown)).toBe(false);
     expect(isStringSet(new Map([['a', 'b']]) as unknown)).toBe(false);
     expect(isStringSet(null as unknown)).toBe(false);
     expect(isStringSet(undefined as unknown)).toBe(false);
@@ -32,5 +33,17 @@ describe('setOf (runtime)', () => {
     expect(isNested(new Set([['a'], ['b', 'c']]))).toBe(true);
     expect(isNested(new Set([['a'], ['b', 1 as any]]))).toBe(false);
     expect(isNested('nope' as unknown)).toBe(false);
+  });
+
+  it('uses the intrinsic iterator for branded sets', () => {
+    const set = new Set(['a']);
+    Object.defineProperty(set, Symbol.iterator, {
+      value: () => {
+        throw new Error('custom iterator should not run');
+      }
+    });
+
+    expect(() => isStringSet(set)).not.toThrow();
+    expect(isStringSet(set)).toBe(true);
   });
 });

--- a/tests/core/object.test.ts
+++ b/tests/core/object.test.ts
@@ -21,6 +21,7 @@ import {
   isFile,
   isInstanceOf
 } from '@/core/object';
+import { runInNewContext } from 'node:vm';
 
 describe('core/object guards', () => {
   it('detects functions and objects', () => {
@@ -57,6 +58,70 @@ describe('core/object guards', () => {
     expect(isPromiseLike({})).toBe(false);
   });
 
+  it('rejects spoofed built-in tags without throwing', () => {
+    const cases: readonly [guard: (value: unknown) => boolean, tag: string][] =
+      [
+        [isDate, 'Date'],
+        [isRegExp, 'RegExp'],
+        [isMap, 'Map'],
+        [isSet, 'Set'],
+        [isWeakMap, 'WeakMap'],
+        [isWeakSet, 'WeakSet'],
+        [isArrayBuffer, 'ArrayBuffer'],
+        [isDataView, 'DataView']
+      ];
+
+    for (const [guard, tag] of cases) {
+      const spoof = { [Symbol.toStringTag]: tag };
+
+      expect(() => guard(spoof)).not.toThrow();
+      expect(guard(spoof)).toBe(false);
+    }
+  });
+
+  it('accepts cross-realm built-ins', () => {
+    const values = runInNewContext(`({
+      date: new Date(),
+      regexp: /test/u,
+      map: new Map(),
+      set: new Set(),
+      weakMap: new WeakMap(),
+      weakSet: new WeakSet(),
+      arrayBuffer: new ArrayBuffer(8),
+      dataView: new DataView(new ArrayBuffer(8))
+    })`) as Record<string, unknown>;
+
+    expect(isDate(values.date)).toBe(true);
+    expect(isRegExp(values.regexp)).toBe(true);
+    expect(isMap(values.map)).toBe(true);
+    expect(isSet(values.set)).toBe(true);
+    expect(isWeakMap(values.weakMap)).toBe(true);
+    expect(isWeakSet(values.weakSet)).toBe(true);
+    expect(isArrayBuffer(values.arrayBuffer)).toBe(true);
+    expect(isDataView(values.dataView)).toBe(true);
+  });
+
+  it('accepts built-in subclasses while preserving valid Date semantics', () => {
+    class DateSubclass extends Date {}
+    class RegExpSubclass extends RegExp {}
+    class MapSubclass extends Map {}
+    class SetSubclass extends Set {}
+    class WeakMapSubclass extends WeakMap {}
+    class WeakSetSubclass extends WeakSet {}
+    class ArrayBufferSubclass extends ArrayBuffer {}
+    class DataViewSubclass extends DataView {}
+
+    expect(isDate(new DateSubclass())).toBe(true);
+    expect(isDate(new DateSubclass('invalid'))).toBe(false);
+    expect(isRegExp(new RegExpSubclass('test'))).toBe(true);
+    expect(isMap(new MapSubclass())).toBe(true);
+    expect(isSet(new SetSubclass())).toBe(true);
+    expect(isWeakMap(new WeakMapSubclass())).toBe(true);
+    expect(isWeakSet(new WeakSetSubclass())).toBe(true);
+    expect(isArrayBuffer(new ArrayBufferSubclass(8))).toBe(true);
+    expect(isDataView(new DataViewSubclass(new ArrayBuffer(8)))).toBe(true);
+  });
+
   it('detects iterable and async iterable', () => {
     const iterableFunction = Object.assign(() => {}, {
       [Symbol.iterator]: function* () {}
@@ -84,6 +149,13 @@ describe('core/object guards', () => {
     expect(isDataView(new DataView(new ArrayBuffer(8)))).toBe(true);
     expect(isTypedArray(new Uint8Array(2))).toBe(true);
     expect(isTypedArray(new DataView(new ArrayBuffer(8)))).toBe(false);
+
+    const spoofedDataView = new DataView(new ArrayBuffer(8));
+    Object.defineProperty(spoofedDataView, Symbol.toStringTag, {
+      value: 'Uint8Array'
+    });
+    expect(isDataView(spoofedDataView)).toBe(true);
+    expect(isTypedArray(spoofedDataView)).toBe(false);
   });
 
   it('detects Error, URL, Blob, File', () => {

--- a/tests/core/object.test.ts
+++ b/tests/core/object.test.ts
@@ -156,6 +156,15 @@ describe('core/object guards', () => {
     });
     expect(isDataView(spoofedDataView)).toBe(true);
     expect(isTypedArray(spoofedDataView)).toBe(false);
+
+    const transferredBuffer = new ArrayBuffer(8);
+    const detachedDataView = new DataView(transferredBuffer);
+    structuredClone(transferredBuffer, { transfer: [transferredBuffer] });
+
+    expect(ArrayBuffer.isView(detachedDataView)).toBe(true);
+    expect(() => detachedDataView.byteLength).toThrow(TypeError);
+    expect(isDataView(detachedDataView)).toBe(true);
+    expect(isTypedArray(detachedDataView)).toBe(false);
   });
 
   it('detects Error, URL, Blob, File', () => {


### PR DESCRIPTION
## Summary

Use intrinsic brand checks for built-ins.

<!-- A brief summary of the changes -->

## Description

- replace tag-based built-in guards with intrinsic brand checks
- reject `Symbol.toStringTag` spoofing without throwing
- preserve support for cross-realm instances and subclasses
- continue rejecting invalid `Date` instances

<!-- A detailed explanation of the changes, including why they are needed -->
