### PR TITLE
docs: add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,32 @@
+# Security Policy
+
+## Supported Versions
+
+Security fixes are provided for the latest released version of `is-kit`.
+
+| Version          | Supported |
+| ---------------- | --------- |
+| Latest release   | Yes       |
+| Earlier releases | No        |
+
+Users should upgrade to the latest version before reporting a vulnerability.
+
+## Reporting a Vulnerability
+
+Please do not open a public GitHub issue for a suspected security vulnerability.
+Instead, report it privately by email to
+[nyaonyao0725@gmail.com](mailto:nyaonyao0725@gmail.com).
+
+Include as much of the following information as possible:
+
+- A description of the vulnerability and its potential impact
+- The affected version or commit
+- Steps to reproduce the issue or a minimal proof of concept
+- Any known mitigations or suggested fixes
+
+We aim to acknowledge reports within seven days. After confirming a
+vulnerability, we will coordinate remediation and disclosure with the reporter.
+Please keep the report confidential until a fix or advisory is published.
+
+If you would like to be credited for the discovery, include your preferred name
+or handle in the report.


### PR DESCRIPTION
## Summary

Add security policy.

<!-- A brief summary of the changes -->

## Description

- Add a security policy for reporting vulnerabilities privately
- Define supported versions and expected response timing
- Document the information maintainers need to investigate reports

<!-- A detailed explanation of the changes, including why they are needed -->
