### PR TITLE
refactor: use direct imports for internal utilities

### DIFF
--- a/src/core/combinators/array.ts
+++ b/src/core/combinators/array.ts
@@ -1,6 +1,6 @@
 import { define } from '../define';
 import type { GuardedOf, Predicate } from '@/types';
-import { everyArrayValue } from '@/utils';
+import { everyArrayValue } from '@/utils/guard-collections';
 
 /**
  * Validates an array where every element satisfies the provided guard.

--- a/src/core/combinators/map.ts
+++ b/src/core/combinators/map.ts
@@ -1,6 +1,6 @@
 import type { GuardedOf, Predicate } from '@/types';
 import { define } from '../define';
-import { everyBrandedMapEntry } from '@/utils';
+import { everyBrandedMapEntry } from '@/utils/guard-collections';
 import { isMap } from '../object';
 
 /**

--- a/src/core/combinators/record.ts
+++ b/src/core/combinators/record.ts
@@ -1,6 +1,6 @@
 import type { GuardedOf, Predicate } from '@/types';
 import { define } from '../define';
-import { everyOwnEnumerableEntry } from '@/utils';
+import { everyOwnEnumerableEntry } from '@/utils/guard-collections';
 import { isPlainObject } from '../object';
 
 /**

--- a/src/core/combinators/set.ts
+++ b/src/core/combinators/set.ts
@@ -1,6 +1,6 @@
 import type { GuardedOf, Predicate } from '@/types';
 import { define } from '../define';
-import { everyBrandedSetValue } from '@/utils';
+import { everyBrandedSetValue } from '@/utils/guard-collections';
 import { isSet } from '../object';
 
 /**

--- a/src/core/combinators/tuple.ts
+++ b/src/core/combinators/tuple.ts
@@ -1,6 +1,6 @@
 import { define } from '../define';
 import type { Predicate, GuardedOf } from '@/types';
-import { everyTupleValue } from '@/utils';
+import { everyTupleValue } from '@/utils/guard-collections';
 
 /**
  * Validates a fixed-length tuple by applying element-wise guards.

--- a/src/core/logic.ts
+++ b/src/core/logic.ts
@@ -6,8 +6,8 @@ import type {
   OutOfGuards,
   Predicate
 } from '@/types';
+import { toBooleanPredicates } from '@/utils/to-boolean-predicates';
 import { define } from './define';
-import { toBooleanPredicates } from '@/utils';
 
 /**
  * Combines a precondition guard with an additional refinement to narrow the type.

--- a/src/core/object.ts
+++ b/src/core/object.ts
@@ -1,6 +1,6 @@
 import { define } from './define';
 import type { Guard } from '@/types';
-import { getTag, OBJECT_TAG_ERROR } from '@/utils';
+import { getTag, OBJECT_TAG_ERROR } from '@/utils/object-tags';
 
 // WHY: DOM constructors such as URL and Blob are declared as constructor
 // objects with a prototype, not as the full Function interface. The helper


### PR DESCRIPTION
## Summary

Use direct imports for internal utilities.

<!-- A brief summary of the changes -->

## Description

Replace internal imports from the `@/utils` barrel with direct module imports.

<!-- A detailed explanation of the changes, including why they are needed -->
