### PR TITLE
chore: deprecate utility exports v2

### DIFF
--- a/.codex/skills/learn/LEARNED_INDEX.md
+++ b/.codex/skills/learn/LEARNED_INDEX.md
@@ -1,0 +1,3 @@
+# Learned Patterns
+
+- **[deprecate-public-api-before-major-removal](learned/deprecate-public-api-before-major-removal.md)** - Deprecate accidental runtime exports during the current major before removing only their public entry point in the next major.

--- a/.codex/skills/learn/SKILL.md
+++ b/.codex/skills/learn/SKILL.md
@@ -1,0 +1,151 @@
+---
+name: learn
+description: Extract reusable patterns from non-trivial work in the is-kit repository and store them as project knowledge. Use after meaningful API design, type-system work, debugging, or compatibility discoveries.
+---
+
+# /learn - Capture Reusable is-kit Patterns
+
+Analyze the current session and capture reusable knowledge for this TypeScript type-guard library.
+
+## Auto-Activation Criteria
+
+Consider auto-activating this skill when:
+
+1. A non-trivial bug was fixed in runtime guard behavior or type inference.
+2. A public API design decision was made and validated with tests.
+3. A tricky TypeScript modeling pattern was discovered.
+4. A runtime/type parity issue was diagnosed and resolved.
+5. The session produced reusable guidance about tests, docs, or release safety for this library.
+
+Do not activate for:
+
+- trivial typo fixes
+- one-line doc wording changes
+- obvious refactors with no reusable lesson
+- patterns already documented in `.codex/skills/learn/learned/`
+
+## Manual Trigger
+
+Run `/learn` after finishing a meaningful implementation, refactor, or debugging session in `is-kit`.
+
+## What To Extract
+
+### 1. Public API Design Patterns
+
+- What API was added or changed?
+- Why was that shape chosen over alternatives?
+- What backward-compatibility constraint mattered?
+- How should similar future APIs be designed?
+
+Project-relevant examples:
+
+- Distinguishing key-level optionality from value-level `undefined`.
+- Choosing a specialized combinator vs. a more generic abstraction.
+- Preserving existing semantics in a minor release while introducing a new helper.
+
+### 2. Type Modeling Patterns
+
+- How were inference, narrowing, or overloads preserved?
+- What TypeScript limitation mattered?
+- What exact type shape or helper solved it?
+
+Project-relevant examples:
+
+- Modeling `struct` schemas with required vs. optional keys.
+- Normalizing intersection-heavy inferred types for `tsd`.
+- Preserving literal narrowing without assertion casts.
+
+### 3. Runtime Validation Patterns
+
+- What runtime behavior needed to match the type-level contract?
+- What edge cases mattered?
+- What implementation detail should future changes preserve?
+
+Project-relevant examples:
+
+- Own-key checks vs. inherited property checks in `struct`.
+- Exact-mode semantics when optional keys are present or absent.
+- Composing schema markers with existing value guards.
+
+### 4. Verification Patterns
+
+- What test mix caught the issue?
+- What commands should be run after similar changes?
+- What docs needed updating to keep the repo consistent?
+
+Project-relevant examples:
+
+- Adding both Jest and `tsd` coverage for public API changes.
+- Running `pnpm build`, `pnpm lint`, `pnpm test`, and `pnpm test:types`.
+- Updating README and docs site examples when semantics change.
+
+## Output Format
+
+Create one file per pattern at:
+
+`.codex/skills/learn/learned/[pattern-name].md`
+
+Template:
+
+````markdown
+# [Descriptive Pattern Name]
+
+**Captured:** YYYY-MM-DD
+**Context:** [When this pattern applies]
+**Tags:** typescript, type-guards, combinators, struct, tsd, api-design, runtime-validation, etc.
+
+## Problem
+
+[Specific recurring problem this pattern solves]
+
+## Solution
+
+[Reusable approach, key decisions, constraints, and tradeoffs]
+
+## Example
+
+```ts
+// Minimal real example from this codebase
+```
+
+## When To Use
+
+[Trigger conditions for applying this pattern]
+
+## Related Files
+
+- `src/core/combinators/struct.ts`
+- `src/types/schema.ts`
+- `tests/core/combinators/struct.test.ts`
+- `tests-d/core/combinators/struct.test-d.ts`
+````
+
+## Process
+
+1. Review the session for candidate learnings.
+2. Select the highest-value reusable pattern(s).
+3. Draft the pattern file.
+4. Ask for user confirmation before saving.
+5. Save to `.codex/skills/learn/learned/`.
+6. Update `.codex/skills/learn/LEARNED_INDEX.md` with a one-line entry.
+
+Index format:
+
+`- **[pattern-name](learned/pattern-name.md)** - One-line summary.`
+
+## Common Pattern Categories For This Repository
+
+- Guard/combinator API design
+- Runtime/type parity in public APIs
+- `struct` schema semantics and exact-mode behavior
+- TypeScript inference and overload design
+- `tsd`-driven regression prevention
+- Object-shape validation edge cases
+- Documentation alignment after API changes
+
+## Notes
+
+- Capture only reusable, non-trivial lessons.
+- Prefer patterns that explain both runtime behavior and type inference.
+- Include the commands and tests that validated the pattern when relevant.
+- Keep entries concrete, searchable, and library-focused.

--- a/.codex/skills/learn/learned/deprecate-public-api-before-major-removal.md
+++ b/.codex/skills/learn/learned/deprecate-public-api-before-major-removal.md
@@ -1,0 +1,74 @@
+# Deprecate Public APIs Before Major Removal
+
+**Captured:** 2026-08-01
+**Context:** Cleaning up root exports that are implemented and used as internal helpers but have already shipped as public API.
+**Tags:** api-design, backward-compatibility, deprecation, exports, release-safety, tsd
+
+## Problem
+
+Barrel exports can expose implementation helpers without a deliberate
+user-facing design. Removing those exports immediately would break consumers,
+while keeping them forever makes the root API harder to understand and expands
+the semantic-versioning surface. Missing documentation or discoverable public
+usage is useful evidence, but it does not prove that private consumers do not
+import an export.
+
+## Solution
+
+Inventory runtime and type-only exports separately, then give every export an
+explicit keep, deprecate, or remove classification.
+
+For a runtime export selected for removal:
+
+1. Keep the export available for the rest of the current major version.
+2. Add an editor-visible `@deprecated` notice and a concrete migration path.
+3. Record the planned removal in the changelog and major-version migration
+   guide.
+4. Keep the exact root-export contract unchanged until the major release.
+5. In the next major, remove only the public re-export when the implementation
+   is still useful internally, then update the exact export contract.
+
+Do not create a new public utility subpath solely to relocate accidental API.
+Require a concrete standalone use case before adding another public boundary.
+Treat type-only exports separately: they have no runtime or bundle cost, so
+remove them only when a specific maintenance or correctness problem justifies
+the break.
+
+## Example
+
+```ts
+// v1: keep the compatibility export while the definition is deprecated.
+export { everyArrayValue } from './utils/guard-collections';
+
+// v2: remove the root re-export. Internal combinators may still import the
+// implementation directly from utils/guard-collections.
+```
+
+For is-kit v2, this process classified all 79 runtime root exports: 73 remain
+public, while six iteration adapters are deprecated during v1 and removed from
+the v2 root entry point.
+
+## When To Use
+
+Use this pattern when a shipped root export looks internal, redundant, poorly
+documented, or inconsistent with the library's public mental model. It is
+especially important when barrel exports made the original public exposure
+easy to overlook.
+
+Validate similar changes with the exact root export contract, runtime and type
+tests, lint, and a package build:
+
+```sh
+pnpm lint
+pnpm build
+pnpm test
+pnpm test:types
+```
+
+## Related Files
+
+- `src/index.ts`
+- `src/utils/guard-collections.ts`
+- `src/utils/to-boolean-predicates.ts`
+- `tests-d/index.test-d.ts`
+- `v2-design.md`

--- a/README.md
+++ b/README.md
@@ -528,6 +528,23 @@ The library is organized around a few small building blocks:
 
 For the full API list and dedicated pages, use the docs site below.
 
+### v2 migration notice
+
+Six low-level utility adapters remain available in v1 for compatibility but are
+deprecated and will no longer be exported from the package root in v2:
+
+| Deprecated export         | Migration path                                                         |
+| ------------------------- | ---------------------------------------------------------------------- |
+| `everyArrayValue`         | Use `Array.prototype.every` or the `arrayOf` guard.                    |
+| `everyTupleValue`         | Use the `tupleOf` guard or compare tuple values directly.              |
+| `everySetValue`           | Use the `setOf` guard or iterate the set directly.                     |
+| `everyMapEntry`           | Use the `mapOf` guard or iterate the map directly.                     |
+| `everyOwnEnumerableEntry` | Use the `recordOf` guard or `Object.entries(value).every(...)`.        |
+| `toBooleanPredicates`     | Use the original predicate array directly; this helper is an identity. |
+
+The underlying internal helpers may remain in the implementation. Only their
+public root exports are planned for removal.
+
 ## 📚 Full Documentation
 
 For detailed API pages and more examples, see:

--- a/src/utils/guard-collections.ts
+++ b/src/utils/guard-collections.ts
@@ -26,6 +26,8 @@ const everyKeyValueEntry = <K, V>(
 /**
  * Checks whether every array element satisfies the provided predicate.
  *
+ * @deprecated Use `Array.prototype.every` for boolean iteration or `arrayOf`
+ * for a narrowing guard. This root export will be removed in is-kit v2.
  * @param values Array values to validate.
  * @param predicate Predicate applied to each element.
  * @returns Whether all elements satisfy `predicate`.
@@ -38,6 +40,8 @@ export const everyArrayValue = (
 /**
  * Checks whether a tuple matches the provided element predicates in order.
  *
+ * @deprecated Use `tupleOf` for a narrowing guard or compare the tuple length
+ * and predicates directly. This root export will be removed in is-kit v2.
  * @param values Tuple candidate values.
  * @param predicates Predicates aligned to each tuple index.
  * @returns Whether lengths match and each index passes.
@@ -59,6 +63,8 @@ export const everyTupleValue = (
 /**
  * Checks whether every set value satisfies the provided predicate.
  *
+ * @deprecated Use `setOf` for a narrowing guard or iterate the set directly.
+ * This root export will be removed in is-kit v2.
  * @param values Set values to validate.
  * @param predicate Predicate applied to each value.
  * @returns Whether all set values satisfy `predicate`.
@@ -80,6 +86,8 @@ export const everyBrandedSetValue = (
 /**
  * Checks whether every map entry satisfies the provided key and value predicates.
  *
+ * @deprecated Use `mapOf` for a narrowing guard or iterate the map directly.
+ * This root export will be removed in is-kit v2.
  * @param values Map values to validate.
  * @param keyPredicate Predicate applied to each key.
  * @param valuePredicate Predicate applied to each value.
@@ -112,6 +120,9 @@ export const everyBrandedMapEntry = (
 /**
  * Checks whether every own enumerable string key/value pair satisfies the provided predicates.
  *
+ * @deprecated Use `recordOf` for a narrowing guard or
+ * `Object.entries(value).every(...)` for boolean iteration. This root export
+ * will be removed in is-kit v2.
  * @param values Plain object values to validate.
  * @param keyPredicate Predicate applied to each enumerable own string key.
  * @param valuePredicate Predicate applied to each corresponding value.

--- a/src/utils/to-boolean-predicates.ts
+++ b/src/utils/to-boolean-predicates.ts
@@ -1,6 +1,8 @@
 /**
  * Converts predicates to plain boolean predicates for iteration helpers.
  *
+ * @deprecated Use the original predicate array directly. This identity helper
+ * will no longer be exported from the package root in is-kit v2.
  * @param predicates Predicates to be treated as simple boolean functions.
  * @returns Readonly array of boolean-returning functions.
  */

--- a/tests-d/index.test-d.ts
+++ b/tests-d/index.test-d.ts
@@ -109,6 +109,8 @@ import type {
 // describe: root entrypoint
 // =============================================
 // it: exports exactly the reviewed public runtime API
+// Note: The six deprecated utility adapters remain part of the v1 compatibility
+// contract and must not be removed until v2.
 const publicRuntimeContract = {
   and,
   andAll,


### PR DESCRIPTION
## Summary

Classify deprecate utility exports v2.

<!-- A brief summary of the changes -->

## Description

- classify all current runtime exports for v2
- deprecate six low-level utility exports while preserving v1 compatibility
- document migration paths and planned v2 removals
<!-- A detailed explanation of the changes, including why they are needed -->
