### PR TITLE
docs: document public type exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -528,6 +528,23 @@ The library is organized around a few small building blocks:
 
 For the full API list and dedicated pages, use the docs site below.
 
+### Public types
+
+Start with the primary types for guard authoring, parsing, and schema inference:
+
+- `Predicate`, `Guard`, `Refinement`, `Refine`, `ParseResult`, `Primitive`
+- `InferSchema`, `StructOptions`, `TypedStructShape`, `TypedStructFields`
+
+Advanced building blocks support reusable wrappers and type-level extensions:
+
+- `GuardedOf`, `GuardedWithin`, `OutOfGuards`, `RefineChain`, `ChainResult`
+- `OptionalSchemaField`, `SchemaField`, `Schema`, `NoExtraKeys`
+- `OptionalObjectKeys`, `RequiredObjectKeys`
+
+Both groups are supported public API and follow semantic versioning. The
+classification only controls discoverability. `SchemaShape` remains internal
+and is not exported from the package root.
+
 ### v2 migration notice
 
 Six low-level utility adapters remain available in v1 for compatibility but are

--- a/docs/app/api-reference/page.tsx
+++ b/docs/app/api-reference/page.tsx
@@ -18,8 +18,8 @@ export default function ApiIndexPage() {
         <Stack gap='xs'>
           <Heading variant='h1'>API Reference</Heading>
           <Paragraph className='text-muted-foreground'>
-            Explore the available functions and combinators. Use the sidebar to
-            navigate.
+            Explore the available functions, combinators, and public types. Use
+            the sidebar to navigate.
           </Paragraph>
         </Stack>
       </Stack>

--- a/docs/app/api-reference/types/page.tsx
+++ b/docs/app/api-reference/types/page.tsx
@@ -1,0 +1,150 @@
+import { ApiReferencePager } from '@/components/api-reference/pager';
+import { CodeBlock } from '@/components/code/code-block';
+import { Heading } from '@/components/ui/heading';
+import { Paragraph } from '@/components/ui/paragraph';
+import { Stack } from '@/components/ui/stack';
+
+const sample = `import { isString, optionalKey, struct } from 'is-kit';
+import type {
+  InferSchema,
+  ParseResult,
+  Predicate,
+  StructOptions,
+} from 'is-kit';
+
+const userSchema = {
+  id: isString,
+  nickname: optionalKey(isString),
+} as const;
+
+type User = InferSchema<typeof userSchema>;
+
+const options: StructOptions = { exact: true };
+const isUser: Predicate<User> = struct(userSchema, options);
+
+declare const result: ParseResult<User>;
+if (result.valid) {
+  result.value.id; // string
+}`;
+
+const primaryTypes = [
+  {
+    name: 'Predicate<T>, Guard<T>',
+    description:
+      'The core unknown-input type guard contract. Guard is a readability alias for Predicate.'
+  },
+  {
+    name: 'Refinement<A, B>, Refine<A, B>',
+    description:
+      'Narrows a known input type A to a subtype B. Refine is a readability alias for Refinement.'
+  },
+  {
+    name: 'ParseResult<T>',
+    description:
+      'The tagged valid/value result returned by safeParse and related helpers.'
+  },
+  {
+    name: 'Primitive',
+    description: 'The union of JavaScript primitive value types.'
+  },
+  {
+    name: 'InferSchema<S>',
+    description:
+      'Infers the readonly object type represented by a struct schema.'
+  },
+  {
+    name: 'StructOptions',
+    description:
+      'The public exact-key options accepted by struct and typedStruct.'
+  },
+  {
+    name: 'TypedStructShape<T>, TypedStructFields<T, S>',
+    description:
+      'Public contracts for annotating wrappers and reusable helpers around typedStruct.'
+  }
+] as const;
+
+const advancedTypes = [
+  {
+    name: 'GuardedOf<F>',
+    description: 'Extracts the guarded output type from one predicate.'
+  },
+  {
+    name: 'OutOfGuards<T>, GuardedWithin<Fs, A>',
+    description:
+      'Extracts and constrains unions produced by collections of guards.'
+  },
+  {
+    name: 'RefineChain<In, T>, ChainResult<In, T>',
+    description:
+      'Models the ordered refinements and final output used by refinement chains.'
+  },
+  {
+    name: 'OptionalSchemaField<G>, SchemaField, Schema',
+    description:
+      'Building blocks for wrappers that accept or construct struct schemas.'
+  },
+  {
+    name: 'NoExtraKeys<S, Shape>',
+    description: 'Rejects keys outside an expected type-level shape.'
+  },
+  {
+    name: 'OptionalObjectKeys<T>, RequiredObjectKeys<T>',
+    description: 'Extracts optional or required keys from an object type.'
+  }
+] as const;
+
+function TypeList({
+  items
+}: {
+  items: readonly { name: string; description: string }[];
+}) {
+  return (
+    <ul className='space-y-3 pl-5 list-disc'>
+      {items.map(({ name, description }) => (
+        <li key={name}>
+          <code>{name}</code> — {description}
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+export default function TypesPage() {
+  return (
+    <Stack variant='main' className='container mx-auto px-4 py-10' gap='xl'>
+      <Stack variant='section' gap='md'>
+        <Stack gap='xs'>
+          <Heading variant='h1'>types</Heading>
+          <Paragraph>
+            Public type exports for guard authoring, parse results, schema
+            inference, and type-level extensions.
+          </Paragraph>
+          <Paragraph className='text-muted-foreground'>
+            Primary and advanced types are equally supported public API. The
+            classification only controls discoverability: start with primary
+            types and reach for advanced types when building reusable wrappers.
+          </Paragraph>
+        </Stack>
+        <CodeBlock code={sample} language='ts' />
+      </Stack>
+
+      <Stack variant='section' gap='md'>
+        <Heading variant='h2'>Primary types</Heading>
+        <TypeList items={primaryTypes} />
+      </Stack>
+
+      <Stack variant='section' gap='md'>
+        <Heading variant='h2'>Advanced building blocks</Heading>
+        <TypeList items={advancedTypes} />
+        <Paragraph className='text-muted-foreground'>
+          <code>SchemaShape</code> is not exported from the package root. It
+          remains an implementation detail unless a concrete external use case
+          requires a public contract.
+        </Paragraph>
+      </Stack>
+
+      <ApiReferencePager currentHref='/api-reference/types' />
+    </Stack>
+  );
+}

--- a/docs/constants/api-items.ts
+++ b/docs/constants/api-items.ts
@@ -57,6 +57,12 @@ export const API_ITEMS: ApiItem[] = [
     description: 'Convert boolean predicates to refinements.'
   },
   {
+    href: '/api-reference/types',
+    title: 'types',
+    description:
+      'Public type contracts for guards, parsing, schemas, and reusable wrappers.'
+  },
+  {
     href: '/api-reference/combinators/array-of',
     title: 'arrayOf',
     description: 'Guard arrays with an element guard.'
@@ -94,7 +100,8 @@ export const API_ITEMS: ApiItem[] = [
   {
     href: '/api-reference/combinators/typed-struct',
     title: 'typedStruct',
-    description: 'Typed struct wrapper that checks fields against an existing object type.'
+    description:
+      'Typed struct wrapper that checks fields against an existing object type.'
   },
   {
     href: '/api-reference/combinators/one-of-values',

--- a/docs/constants/api-sections.ts
+++ b/docs/constants/api-sections.ts
@@ -13,7 +13,8 @@ export const apiSections: SidebarSection[] = [
       { href: '/api-reference/key', label: 'key' },
       { href: '/api-reference/primitive', label: 'primitive' },
       { href: '/api-reference/object', label: 'object' },
-      { href: '/api-reference/predicate', label: 'predicate' }
+      { href: '/api-reference/predicate', label: 'predicate' },
+      { href: '/api-reference/types', label: 'types' }
     ]
   },
   {

--- a/src/types/core.ts
+++ b/src/types/core.ts
@@ -1,32 +1,42 @@
+/** Predicate that accepts an unknown value and narrows it to `T`. */
 export type Predicate<T> = (value: unknown) => value is T;
 
+/** Refinement that narrows a known input type `A` to its subtype `B`. */
 export type Refinement<A, B extends A> = (value: A) => value is B;
 
+/** Readability alias for {@link Predicate}. */
 export type Guard<T> = Predicate<T>;
 
+/** Readability alias for {@link Refinement}. */
 export type Refine<A, B extends A> = Refinement<A, B>;
 
+/** Validates the ordered refinement types accepted by `andAll`. */
 export type RefineChain<In, T extends readonly unknown[]> = T extends []
   ? []
   : T extends [Refine<In, infer Next>, ...infer R]
     ? [Refine<In, Next>, ...RefineChain<Next, Extract<R, readonly unknown[]>>]
     : never;
 
+/** Resolves the final narrowed type produced by an ordered refinement chain. */
 export type ChainResult<In, T extends readonly unknown[]> = T extends []
   ? In
   : T extends [Refine<In, infer Next>, ...infer R]
     ? ChainResult<Next, Extract<R, readonly unknown[]>>
     : never;
 
+/** Extracts the union of output types from a readonly guard collection. */
 export type OutOfGuards<T extends readonly Guard<unknown>[]> =
   T[number] extends Guard<infer U> ? U : never;
 
+/** Tagged validation result returned by safe parse helpers. */
 export type ParseResult<T> = { valid: true; value: T } | { valid: false };
 
+/** Extracts the narrowed output type from a predicate. */
 export type GuardedOf<F> = F extends ((value: unknown) => value is infer G)
   ? G
   : never;
 
+/** Extracts guard outputs that remain assignable to a known input type. */
 export type GuardedWithin<Fs, A> = Extract<
   Fs extends readonly unknown[] ? GuardedOf<Fs[number]> : never,
   A

--- a/src/types/primitive.ts
+++ b/src/types/primitive.ts
@@ -1,3 +1,4 @@
+/** Union of JavaScript primitive value types. */
 export type Primitive =
   | string
   | number


### PR DESCRIPTION
## Summary

Document public type exports.

<!-- A brief summary of the changes -->

## Description

- classify all 21 public type exports as primary or advanced
- add a dedicated public types API reference page

<!-- A detailed explanation of the changes, including why they are needed -->
