### PR TITLE
feat: add internal decoder

### DIFF
--- a/.codex/skills/learn/LEARNED_INDEX.md
+++ b/.codex/skills/learn/LEARNED_INDEX.md
@@ -1,3 +1,4 @@
 # Learned Patterns
 
 - **[deprecate-public-api-before-major-removal](learned/deprecate-public-api-before-major-removal.md)** - Deprecate accidental runtime exports during the current major before removing only their public entry point in the next major.
+- **[model-transformations-as-decoders](learned/model-transformations-as-decoders.md)** - Model value-changing boundary conversions as ParseResult-returning decoder functions rather than type guards.

--- a/.codex/skills/learn/learned/model-transformations-as-decoders.md
+++ b/.codex/skills/learn/learned/model-transformations-as-decoders.md
@@ -1,0 +1,98 @@
+# Model Transformations as Decoders, Not Guards
+
+**Captured:** 2026-08-01
+**Context:** Modeling explicit boundary conversions where the output is a new value rather than a narrower view of the input.
+**Tags:** api-design, typescript, decoder, parse-result, type-guards, tsd, composition
+
+## Problem
+
+A type guard can only narrow the value it receives. It cannot correctly model a
+conversion such as string to number because the output is a different value.
+Pretending that coercion is a predicate weakens the guard-first mental model and
+hides when data changes representation.
+
+The transformation contract must also stay small enough that core does not grow
+into an error-reporting or transformation framework before boundary modules
+demonstrate that need.
+
+## Solution
+
+Model explicit transformations as function types that return the existing
+tagged parse result:
+
+```ts
+export type Decoder<Input, Output> = (
+  input: Input
+) => ParseResult<Output>;
+```
+
+Use these rules for the base contract:
+
+- expected conversion failures return `{ valid: false }`
+- successful conversions return `{ valid: true, value: Output }`
+- unexpected exceptions propagate to the caller
+- sequential composition calls the next decoder only after success
+- codes, messages, inputs, paths, and composition helpers stay outside the base
+  abstraction until repeated use proves they are needed
+- keep the contract internal while prototyping the boundary module that needs
+  it
+
+Concrete conversion policy belongs to each decoder. For example, whether a
+number decoder accepts whitespace or alternate numeric syntax is not part of
+the generic `Decoder` contract.
+
+## Example
+
+```ts
+const stringToNumber: Decoder<string, number> = (input) => {
+  if (input.trim() === '') return { valid: false };
+
+  const value = Number(input);
+  return Number.isFinite(value) ? { valid: true, value } : { valid: false };
+};
+
+const numberToBoolean: Decoder<number, boolean> = (input) => ({
+  valid: true,
+  value: input !== 0
+});
+
+const stringToBoolean: Decoder<string, boolean> = (input) => {
+  const result = stringToNumber(input);
+  return result.valid ? numberToBoolean(result.value) : result;
+};
+```
+
+For negative tsd assertions, prefer an assignability assertion over calling a
+function with an invalid argument:
+
+```ts
+expectNotAssignable<Parameters<typeof stringToNumber>[0]>(42);
+```
+
+`expectError(stringToNumber(42))` passes under tsd, but the invalid call still
+appears as a TypeScript error in VSCode. `expectNotAssignable` preserves the
+negative test while keeping `tests-d/tsconfig.json` clean in the editor.
+
+## When To Use
+
+Use this pattern for explicit coercion or decoding at string, URL, environment,
+form, or similar boundaries. Continue using `Predicate<T>` when validation only
+narrows the original value without creating a replacement.
+
+Verify both tsd behavior and the editor's TypeScript project:
+
+```sh
+pnpm test:types
+node_modules/.bin/tsc -p tests-d/tsconfig.json --pretty false
+pnpm lint
+pnpm build
+pnpm test
+```
+
+## Related Files
+
+- `src/types/core.ts`
+- `tests-d/types/decoder.test-d.ts`
+- `tests-d/core/key.test-d.ts`
+- `tests-d/tsconfig.json`
+- `v2-design.md`

--- a/src/types/core.ts
+++ b/src/types/core.ts
@@ -28,8 +28,11 @@ export type ChainResult<In, T extends readonly unknown[]> = T extends []
 export type OutOfGuards<T extends readonly Guard<unknown>[]> =
   T[number] extends Guard<infer U> ? U : never;
 
-/** Tagged validation result returned by safe parse helpers. */
+/** Tagged success/failure result containing the value when valid. */
 export type ParseResult<T> = { valid: true; value: T } | { valid: false };
+
+/** Function that explicitly transforms an input into a parsed output value. */
+export type Decoder<Input, Output> = (input: Input) => ParseResult<Output>;
 
 /** Extracts the narrowed output type from a predicate. */
 export type GuardedOf<F> = F extends ((value: unknown) => value is infer G)

--- a/tests-d/core/key.test-d.ts
+++ b/tests-d/core/key.test-d.ts
@@ -1,4 +1,4 @@
-import { expectError, expectType } from 'tsd';
+import { expectNotAssignable, expectType } from 'tsd';
 import {
   hasKey,
   hasKeys,
@@ -59,4 +59,4 @@ if (hasKindAndId(candidate)) {
 }
 
 // it: rejects empty keys at compile time
-expectError(hasKeys());
+expectNotAssignable<Parameters<typeof hasKeys>>([]);

--- a/tests-d/types/decoder.test-d.ts
+++ b/tests-d/types/decoder.test-d.ts
@@ -1,0 +1,34 @@
+import { expectNotAssignable, expectType } from 'tsd';
+import type { Decoder, ParseResult } from '@/types';
+
+// =============================================
+// describe: Decoder
+// =============================================
+// it: models an explicit input-to-output transformation
+// Note: Numeric syntax policy belongs to the concrete decoder, not the contract.
+const stringToNumber: Decoder<string, number> = (input) => {
+  if (input.trim() === '') return { valid: false };
+
+  const value = Number(input);
+  return Number.isFinite(value) ? { valid: true, value } : { valid: false };
+};
+
+expectType<Decoder<string, number>>(stringToNumber);
+expectType<ParseResult<number>>(stringToNumber('42'));
+expectNotAssignable<Parameters<typeof stringToNumber>[0]>(42);
+
+// it: composes by passing successful output to the next decoder
+const numberToBoolean: Decoder<number, boolean> = (input) => ({
+  valid: true,
+  value: input !== 0
+});
+
+const stringToBoolean: Decoder<string, boolean> = (input) => {
+  const numberResult = stringToNumber(input);
+  return numberResult.valid
+    ? numberToBoolean(numberResult.value)
+    : numberResult;
+};
+
+expectType<ParseResult<boolean>>(stringToBoolean('1'));
+expectNotAssignable<Parameters<typeof stringToBoolean>[0]>(true);


### PR DESCRIPTION
## Summary

Add internal decoder.

<!-- A brief summary of the changes -->

## Description

- add an internal function-based `Decoder<Input, Output>` contract
- reuse `ParseResult<Output>` for explicit transformations

<!-- A detailed explanation of the changes, including why they are needed -->
