### PR TITLE
test: add packed package smoke coverage

### DIFF
--- a/.codex/skills/learn/LEARNED_INDEX.md
+++ b/.codex/skills/learn/LEARNED_INDEX.md
@@ -2,3 +2,4 @@
 
 - **[deprecate-public-api-before-major-removal](learned/deprecate-public-api-before-major-removal.md)** - Deprecate accidental runtime exports during the current major before removing only their public entry point in the next major.
 - **[model-transformations-as-decoders](learned/model-transformations-as-decoders.md)** - Model value-changing boundary conversions as ParseResult-returning decoder functions rather than type guards.
+- **[test-packed-artifacts-from-a-consumer-project](learned/test-packed-artifacts-from-a-consumer-project.md)** - Install the packed tarball in a temporary consumer to verify ESM, CommonJS, and declaration resolution before publishing.

--- a/.codex/skills/learn/learned/test-packed-artifacts-from-a-consumer-project.md
+++ b/.codex/skills/learn/learned/test-packed-artifacts-from-a-consumer-project.md
@@ -61,6 +61,7 @@ resolution regressions.
 Verify with:
 
 ```sh
+pnpm build
 pnpm test:package
 pnpm lint
 pnpm test

--- a/.codex/skills/learn/learned/test-packed-artifacts-from-a-consumer-project.md
+++ b/.codex/skills/learn/learned/test-packed-artifacts-from-a-consumer-project.md
@@ -1,0 +1,77 @@
+# Test Packed Artifacts From a Consumer Project
+
+**Captured:** 2026-08-02
+**Context:** Verifying that the npm artifact consumers install matches the source-level public API contract.
+**Tags:** release-safety, packaging, npm, esm, commonjs, typescript, smoke-testing, ci
+
+## Problem
+
+Source-level runtime and type tests can pass while the published package is
+broken. In is-kit, type tests map `is-kit` directly to `src/index.ts`, so they do
+not exercise `package.json` export conditions, generated `dist` files, the
+published file allowlist, or consumer-side declaration resolution.
+
+A successful build is also insufficient: it proves that artifacts were
+generated, but not that Node and TypeScript can resolve them through the packed
+package metadata.
+
+## Solution
+
+Build the package, create the real npm tarball, and install that tarball into a
+temporary consumer project. Run independent checks through the installed
+package name:
+
+1. Import runtime exports from an ESM file.
+2. Require runtime exports from a CommonJS file.
+3. Compile a strict `NodeNext` TypeScript file importing public values and
+   types.
+
+Use a temporary npm cache so the smoke test does not depend on or mutate the
+developer's global cache. Install only the local tarball with lifecycle scripts,
+audits, funding output, and lockfile generation disabled. Always remove the
+temporary project in a `finally` block.
+
+Run this check on pull requests that change the build and again immediately
+before npm publication. The source-level exact export contract and packed
+consumer smoke cover different failure modes, so retain both.
+
+## Example
+
+```js
+run('npm', ['pack', '--pack-destination', packageDirectory], repositoryRoot);
+run('npm', ['install', '--ignore-scripts', '--no-audit', tarballPath]);
+
+run(process.execPath, ['esm-smoke.mjs']);
+run(process.execPath, ['cjs-smoke.cjs']);
+run(process.execPath, [typescriptCli, '--project', 'tsconfig.json']);
+```
+
+Discover the generated `.tgz` in the isolated package directory instead of
+depending on human-oriented npm stdout. This remains stable when command
+wrappers or environment settings alter npm output formatting.
+
+## When To Use
+
+Use this pattern before releases and whenever package exports, entry points,
+build output, declaration bundling, or the npm `files` list changes. It is
+especially important before a major-version public export cleanup because it
+confirms that intentional removals do not mask unrelated ESM, CommonJS, or type
+resolution regressions.
+
+Verify with:
+
+```sh
+pnpm test:package
+pnpm lint
+pnpm test
+pnpm test:types
+```
+
+## Related Files
+
+- `tests/package-smoke.mjs`
+- `package.json`
+- `mise.toml`
+- `.github/workflows/build.yaml`
+- `.github/workflows/npm-publish.yaml`
+- `tests-d/index.test-d.ts`

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,5 +13,5 @@ jobs:
         uses: actions/checkout@v6
       - name: Setup project
         uses: ./.github/actions/setup-project
-      - name: Run build
-        run: mise run build
+      - name: Build and smoke-test package artifact
+        run: mise run test-package

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,5 +13,7 @@ jobs:
         uses: actions/checkout@v6
       - name: Setup project
         uses: ./.github/actions/setup-project
-      - name: Build and smoke-test package artifact
+      - name: Run build
+        run: mise run build
+      - name: Smoke-test package artifact
         run: mise run test-package

--- a/.github/workflows/npm-publish.yaml
+++ b/.github/workflows/npm-publish.yaml
@@ -31,8 +31,8 @@ jobs:
       - name: Test
         run: mise run test
 
-      - name: Build package
-        run: mise run build
+      - name: Build and smoke-test package artifact
+        run: mise run test-package
 
       - name: Verify tag matches package.json version
         run: |

--- a/.github/workflows/npm-publish.yaml
+++ b/.github/workflows/npm-publish.yaml
@@ -31,7 +31,10 @@ jobs:
       - name: Test
         run: mise run test
 
-      - name: Build and smoke-test package artifact
+      - name: Build package
+        run: mise run build
+
+      - name: Smoke-test package artifact
         run: mise run test-package
 
       - name: Verify tag matches package.json version

--- a/README.md
+++ b/README.md
@@ -576,6 +576,7 @@ Requires Node 22.22.0 and pnpm 11.2.2.
 - `pnpm build`
 - `pnpm test`
 - `pnpm test:types`
+- `pnpm test:package`
 
 See `DEVELOPER.md` for setup details and `CONTRIBUTE.md` for contribution workflow.
 

--- a/mise.toml
+++ b/mise.toml
@@ -33,9 +33,13 @@ run = "pnpm test"
 description = "Run tsd type tests"
 run = "pnpm test:types"
 
+[tasks.test-package]
+description = "Build and smoke-test the packed npm artifact"
+run = "pnpm test:package"
+
 [tasks.ci]
-description = "Run lint, build, runtime and type tests"
-depends = ["lint", "build", "test", "test-types"]
+description = "Run lint, package smoke, runtime and type tests"
+depends = ["lint", "test", "test-types", "test-package"]
 
 [tasks.hook-oxfmt]
 description = "Run Oxfmt for lefthook"

--- a/mise.toml
+++ b/mise.toml
@@ -34,12 +34,12 @@ description = "Run tsd type tests"
 run = "pnpm test:types"
 
 [tasks.test-package]
-description = "Build and smoke-test the packed npm artifact"
+description = "Smoke-test the packed npm artifact"
 run = "pnpm test:package"
 
 [tasks.ci]
-description = "Run lint, package smoke, runtime and type tests"
-depends = ["lint", "test", "test-types", "test-package"]
+description = "Run lint, build, runtime and type tests"
+depends = ["lint", "build", "test", "test-types"]
 
 [tasks.hook-oxfmt]
 description = "Run Oxfmt for lefthook"

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "scripts": {
     "test": "jest",
     "test:types": "tsd",
+    "test:package": "pnpm build && node tests/package-smoke.mjs",
     "lint": "oxlint .",
     "format": "oxfmt .",
     "format:check": "oxfmt --check .",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "test": "jest",
     "test:types": "tsd",
-    "test:package": "pnpm build && node tests/package-smoke.mjs",
+    "test:package": "node tests/package-smoke.mjs",
     "lint": "oxlint .",
     "format": "oxfmt .",
     "format:check": "oxfmt --check .",

--- a/tests/package-smoke.mjs
+++ b/tests/package-smoke.mjs
@@ -1,0 +1,125 @@
+import { execFileSync } from 'node:child_process';
+import {
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  rmSync,
+  writeFileSync
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const temporaryRoot = mkdtempSync(join(tmpdir(), 'is-kit-package-smoke-'));
+const packageDirectory = join(temporaryRoot, 'package');
+const consumerDirectory = join(temporaryRoot, 'consumer');
+const npmCacheDirectory = join(temporaryRoot, 'npm-cache');
+const npmEnvironment = {
+  ...process.env,
+  npm_config_cache: npmCacheDirectory,
+  npm_config_update_notifier: 'false'
+};
+
+const run = (command, args, cwd = consumerDirectory) =>
+  execFileSync(command, args, {
+    cwd,
+    env: npmEnvironment,
+    stdio: 'inherit'
+  });
+
+const writeConsumerFile = (name, contents) =>
+  writeFileSync(join(consumerDirectory, name), contents);
+
+try {
+  mkdirSync(packageDirectory, { recursive: true });
+  mkdirSync(consumerDirectory, { recursive: true });
+
+  run('npm', ['pack', '--pack-destination', packageDirectory], repositoryRoot);
+  const [filename] = readdirSync(packageDirectory).filter((name) =>
+    name.endsWith('.tgz')
+  );
+  if (!filename) throw new Error('npm pack did not create a tarball');
+  const tarballPath = join(packageDirectory, filename);
+
+  writeConsumerFile(
+    'package.json',
+    `${JSON.stringify({ private: true, type: 'module' }, null, 2)}\n`
+  );
+
+  run('npm', [
+    'install',
+    '--ignore-scripts',
+    '--no-audit',
+    '--no-fund',
+    '--package-lock=false',
+    tarballPath
+  ]);
+
+  writeConsumerFile(
+    'esm-smoke.mjs',
+    `import assert from 'node:assert/strict';
+import { arrayOf, isString } from 'is-kit';
+
+assert.equal(isString('value'), true);
+assert.equal(arrayOf(isString)(['a', 'b']), true);
+assert.equal(arrayOf(isString)(['a', 1]), false);
+`
+  );
+
+  writeConsumerFile(
+    'cjs-smoke.cjs',
+    `const assert = require('node:assert/strict');
+const { arrayOf, isString } = require('is-kit');
+
+assert.equal(isString('value'), true);
+assert.equal(arrayOf(isString)(['a', 'b']), true);
+assert.equal(arrayOf(isString)(['a', 1]), false);
+`
+  );
+
+  writeConsumerFile(
+    'types-smoke.ts',
+    `import { arrayOf, isString, safeParse } from 'is-kit';
+import type { ParseResult, Predicate } from 'is-kit';
+
+const isStringArray: Predicate<readonly string[]> = arrayOf(isString);
+const result: ParseResult<string> = safeParse(isString, 'value');
+
+void isStringArray;
+void result;
+`
+  );
+
+  writeConsumerFile(
+    'tsconfig.json',
+    `${JSON.stringify(
+      {
+        compilerOptions: {
+          module: 'NodeNext',
+          moduleResolution: 'NodeNext',
+          noEmit: true,
+          strict: true,
+          target: 'ES2022'
+        },
+        files: ['types-smoke.ts']
+      },
+      null,
+      2
+    )}\n`
+  );
+
+  run(process.execPath, ['esm-smoke.mjs']);
+  run(process.execPath, ['cjs-smoke.cjs']);
+  run(process.execPath, [
+    resolve(repositoryRoot, 'node_modules/typescript/bin/tsc'),
+    '--project',
+    'tsconfig.json',
+    '--pretty',
+    'false'
+  ]);
+
+  console.log('Package smoke test passed for ESM, CJS, and TypeScript.');
+} finally {
+  rmSync(temporaryRoot, { recursive: true, force: true });
+}


### PR DESCRIPTION
## Summary

Add packed package smoke coverage.

<!-- A brief summary of the changes -->

## Description

- add a package smoke test that installs the packed npm tarball into a temporary consumer project
- verify ESM imports, CommonJS require, and published TypeScript declarations

<!-- A detailed explanation of the changes, including why they are needed -->
