### PR TITLE
feat: add Codex Marketplace skill

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "is-kit",
+  "interface": {
+    "displayName": "is-kit"
+  },
+  "plugins": [
+    {
+      "name": "is-kit",
+      "source": {
+        "source": "local",
+        "path": "./plugins/is-kit"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Developer Tools"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -172,8 +172,23 @@ const isSlug = (value: unknown): value is string =>
 
 ### AI agent setup
 
-Add the recommended `is-kit` selection and usage rules to a repository's AI
-agent instructions:
+#### Recommended: Codex Marketplace plugin
+
+Install the `is-kit` plugin from this repository's Codex Marketplace:
+
+```bash
+codex plugin marketplace add nyaomaru/is-kit
+codex plugin add is-kit@is-kit
+```
+
+This is the primary distribution channel for the `use-is-kit` skill. It gives
+Codex an on-demand workflow for selecting guards, replacing manual runtime
+checks, and validating object boundaries with `is-kit`.
+
+#### Compatibility: instruction-only setup
+
+For agents that do not support skills or plugins, add the lightweight selection
+and usage rules to the repository's agent instructions:
 
 ```bash
 npx --yes is-kit@latest init-agent

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -38,4 +38,13 @@ const result = safeParse(isUser, input);
 
 ## AI agent setup
 
-Run `npx --yes is-kit@latest init-agent` in a consumer repository to add the recommended selection and usage rules to `AGENTS.md`. Use `npx --yes is-kit@latest init-agent --target claude` for `CLAUDE.md`.
+The recommended setup for Codex is the `is-kit` Marketplace plugin:
+
+```bash
+codex plugin marketplace add nyaomaru/is-kit
+codex plugin add is-kit@is-kit
+```
+
+The plugin provides the on-demand `use-is-kit` skill for guard selection, migrations, and object-boundary validation. The skill is distributed through the Git Marketplace and is not included in the `is-kit` npm package.
+
+For agents that do not support skills or plugins, run `npx --yes is-kit@latest init-agent` to add lightweight selection and usage rules to `AGENTS.md`. Use `npx --yes is-kit@latest init-agent --target claude` for `CLAUDE.md`.

--- a/plugins/is-kit/.codex-plugin/plugin.json
+++ b/plugins/is-kit/.codex-plugin/plugin.json
@@ -1,0 +1,32 @@
+{
+  "name": "is-kit",
+  "version": "0.1.0",
+  "description": "Build and migrate composable TypeScript runtime type guards with is-kit.",
+  "author": {
+    "name": "nyaomaru",
+    "url": "https://github.com/nyaomaru"
+  },
+  "homepage": "https://is-kit-docs.vercel.app/",
+  "repository": "https://github.com/nyaomaru/is-kit",
+  "license": "MIT",
+  "keywords": [
+    "typescript",
+    "type-guards",
+    "runtime-validation",
+    "type-narrowing"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "is-kit",
+    "shortDescription": "Build and migrate TypeScript type guards.",
+    "longDescription": "Create, compose, migrate, and review TypeScript runtime type guards with is-kit while preserving natural control-flow narrowing.",
+    "developerName": "nyaomaru",
+    "category": "Developer Tools",
+    "capabilities": ["Read", "Write"],
+    "websiteURL": "https://is-kit-docs.vercel.app/",
+    "defaultPrompt": [
+      "Replace manual TypeScript checks with composable is-kit guards.",
+      "Validate an unknown API response with is-kit."
+    ]
+  }
+}

--- a/plugins/is-kit/skills/use-is-kit/SKILL.md
+++ b/plugins/is-kit/skills/use-is-kit/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: use-is-kit
+description: Create, compose, migrate, and review TypeScript runtime type guards with is-kit. Use when adding reusable guards; replacing typeof, null checks, or handwritten type predicates; narrowing unknown values; validating JSON or API responses; building collection or object schemas with struct or typedStruct; or reviewing existing is-kit usage. Do not use for one-off environment checks or validation that requires data transformation or rich error reporting.
+---
+
+# Use is-kit
+
+Build runtime checks that preserve TypeScript control-flow narrowing without
+inventing project architecture or duplicating guards that already exist.
+
+## 1. Inspect before editing
+
+1. Read the repository instructions and relevant package scripts.
+2. Confirm the installed `is-kit` version from the package manifest and lockfile.
+3. Inspect the installed declarations, package exports, or monorepo source before
+   relying on an API name. Prefer the installed version over online examples.
+4. Search for an equivalent local guard, wrapper, barrel export, schema, or
+   established import boundary.
+5. Reuse an existing guard when it already expresses the required semantics.
+
+Do not add a wrapper layer merely because this skill mentions one. If the
+project already has an `is-kit` boundary, respect it; otherwise import from
+`is-kit` directly.
+
+## 2. Choose the smallest correct guard
+
+Read [guard-selection.md](references/guard-selection.md) when choosing between
+built-ins, logical combinators, custom predicates, equality guards, and
+collection combinators.
+
+For object or API response validation, always read
+[object-validation.md](references/object-validation.md) before choosing
+`struct`, `typedStruct`, `optionalKey`, or `safeParse`.
+
+For replacement or cleanup work, read
+[migration-checklist.md](references/migration-checklist.md) before changing
+manual checks.
+
+Prefer composition over a handwritten type-predicate signature. Keep guards
+total, deterministic, and side-effect free.
+
+## 3. Place the guard by responsibility
+
+- Put broadly reusable, domain-free guards in the project's existing shared
+  guard location, if one exists.
+- Keep a schema beside the boundary that consumes the validated value when the
+  schema exists for one API, file, parser, or integration.
+- Keep business decisions and domain state predicates in their owning feature
+  or domain module.
+- Add or update barrel exports only when the project already uses them.
+- Follow the repository's naming, documentation, and test-collocation rules.
+
+Avoid creating a global guard from a one-off payload projection. Avoid moving
+domain knowledge into a generic guard module.
+
+## 4. Implement without weakening the boundary
+
+- Accept untrusted input as `unknown`.
+- Narrow before reading or returning typed data.
+- Remove an `as` assertion when the new guard makes it unnecessary.
+- Store an indexed property in a local constant before narrowing when
+  TypeScript does not retain the property refinement.
+- Use `safeParse` when the success branch consumes the validated value; call a
+  guard directly when only a boolean decision is needed.
+- Default to forward-compatible object validation. Reject extra keys only when
+  the contract explicitly requires an exact object.
+
+## 5. Verify behavior and types
+
+Add focused tests using the project's existing test tools:
+
+- at least one accepted value;
+- at least one rejected value;
+- at least one value of the wrong runtime type;
+- object cases for missing, optional, and extra keys when relevant;
+- type-level assertions when the repository already tests inference or
+  narrowing.
+
+Run the narrowest relevant test, typecheck, lint, and formatting commands.
+Inspect the final diff for unrelated formatting or generated-file changes.
+
+## Boundaries
+
+- Do not replace runtime or platform detection such as
+  `typeof window === 'undefined'` merely for stylistic consistency.
+- Do not replace a clear one-off primitive check unless reuse, composition, or
+  narrowing materially improves.
+- Do not upgrade `is-kit` unless the task requires an API unavailable in the
+  installed version or the user requests the upgrade.
+- Recommend a schema validator instead when the requirement depends on data
+  transformation, coercion, detailed issue paths, or rich validation errors.

--- a/plugins/is-kit/skills/use-is-kit/agents/openai.yaml
+++ b/plugins/is-kit/skills/use-is-kit/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: 'Use is-kit'
+  short_description: 'Build and migrate TypeScript type guards'
+  default_prompt: 'Use $use-is-kit to replace manual runtime checks with composable is-kit guards.'

--- a/plugins/is-kit/skills/use-is-kit/references/guard-selection.md
+++ b/plugins/is-kit/skills/use-is-kit/references/guard-selection.md
@@ -1,0 +1,120 @@
+# Guard selection
+
+Use the installed `is-kit` declarations as the source of truth. This reference
+describes selection strategy, not a guarantee that every API exists in every
+version.
+
+## Decision table
+
+| Need                                            | Prefer                                                                               |
+| ----------------------------------------------- | ------------------------------------------------------------------------------------ | ------- |
+| Primitive or platform value                     | Existing `isString`, `isNumber`, `isBoolean`, `isDate`, `isError`, and similar guard |
+| Exact primitive literal                         | `equals(value)` or `oneOfValues(...)`                                                |
+| Union of guarded types                          | `or(...)`                                                                            |
+| Base guard plus one refinement                  | `and(base, refinement)`                                                              |
+| Base guard plus multiple narrowing steps        | `andAll(base, ...steps)`                                                             |
+| Reusable negation                               | `not(guard)`                                                                         |
+| Accept `null`, `undefined`, or both             | `nullable`, `optional`, or `nullish`                                                 |
+| Direct `null                                    | undefined` check                                                                     | `isNil` |
+| Custom guard from an `unknown` runtime check    | `define<T>(check)`                                                                   |
+| Boolean condition over an already narrowed type | `predicateToRefine<T>(check)`                                                        |
+| Homogeneous array, record, set, or map          | Matching collection combinator                                                       |
+| Fixed tuple                                     | `tupleOf(...)`                                                                       |
+| Object payload                                  | `struct(...)` or `typedStruct<T>()(...)`                                             |
+
+## Reuse before composition
+
+Search in this order:
+
+1. An equivalent project guard or schema.
+2. An equivalent export in the installed `is-kit` version.
+3. A composition of existing guards.
+4. A new custom guard.
+
+Do not create aliases whose only purpose is renaming unless the project uses a
+guard boundary or the alias establishes meaningful domain vocabulary.
+
+## Primitive semantics
+
+Confirm semantics instead of choosing by name alone. For example, current
+versions distinguish a finite-number guard from a number-primitive guard that
+also accepts `NaN` and infinities. Select the behavior required by the runtime
+contract.
+
+```ts
+import { isNumber, isNumberPrimitive } from 'is-kit';
+
+isNumber(Infinity); // false
+isNumberPrimitive(Infinity); // true
+```
+
+## Logical composition
+
+Create reusable unions and refinements with combinators so inference survives
+reuse.
+
+```ts
+import { and, isNumber, isString, or, predicateToRefine } from 'is-kit';
+
+export const isIdentifier = or(isString, isNumber);
+
+export const isNonEmptyString = and(
+  isString,
+  predicateToRefine<string>((value) => value.length > 0)
+);
+```
+
+Use `define<T>` when the complete runtime check starts from `unknown`:
+
+```ts
+import { define, isString } from 'is-kit';
+
+export const isSlug = define<string>(
+  (value) => isString(value) && /^[a-z0-9-]+$/.test(value)
+);
+```
+
+Do not write a type-predicate annotation solely to convince TypeScript that an
+unchecked boolean function is a guard.
+
+## Nullability
+
+Distinguish value optionality from object-key optionality:
+
+```ts
+import { isString, nullish, optional } from 'is-kit';
+
+const isOptionalStringValue = optional(isString);
+const isNullishStringValue = nullish(isString);
+```
+
+Use `optionalKey` only inside `struct` or `typedStruct`; see
+[object-validation.md](object-validation.md).
+
+## Literals and discriminants
+
+Use literal guards rather than repeating equality chains:
+
+```ts
+import { equalsKey, oneOfValues } from 'is-kit';
+
+const isStatus = oneOfValues('idle', 'loading', 'success', 'error');
+const isSuccessResult = equalsKey('status', 'success');
+```
+
+Use `equalsKey` for a discriminant check, not as a substitute for validating
+the rest of a payload that will be consumed.
+
+## Collections
+
+Use the combinator matching the runtime container and contract:
+
+```ts
+import { arrayOf, isNumber, isString, recordOf, tupleOf } from 'is-kit';
+
+const isNames = arrayOf(isString);
+const isScores = recordOf(isString, isNumber);
+const isPoint = tupleOf(isNumber, isNumber);
+```
+
+Use `nonEmptyArrayOf` only when non-emptiness is part of the runtime contract.

--- a/plugins/is-kit/skills/use-is-kit/references/guard-selection.md
+++ b/plugins/is-kit/skills/use-is-kit/references/guard-selection.md
@@ -7,7 +7,7 @@ version.
 ## Decision table
 
 | Need                                            | Prefer                                                                               |
-| ----------------------------------------------- | ------------------------------------------------------------------------------------ | ------- |
+| ----------------------------------------------- | ------------------------------------------------------------------------------------ |
 | Primitive or platform value                     | Existing `isString`, `isNumber`, `isBoolean`, `isDate`, `isError`, and similar guard |
 | Exact primitive literal                         | `equals(value)` or `oneOfValues(...)`                                                |
 | Union of guarded types                          | `or(...)`                                                                            |
@@ -15,7 +15,7 @@ version.
 | Base guard plus multiple narrowing steps        | `andAll(base, ...steps)`                                                             |
 | Reusable negation                               | `not(guard)`                                                                         |
 | Accept `null`, `undefined`, or both             | `nullable`, `optional`, or `nullish`                                                 |
-| Direct `null                                    | undefined` check                                                                     | `isNil` |
+| Direct `null \| undefined` check                | `isNil`                                                                              |
 | Custom guard from an `unknown` runtime check    | `define<T>(check)`                                                                   |
 | Boolean condition over an already narrowed type | `predicateToRefine<T>(check)`                                                        |
 | Homogeneous array, record, set, or map          | Matching collection combinator                                                       |

--- a/plugins/is-kit/skills/use-is-kit/references/migration-checklist.md
+++ b/plugins/is-kit/skills/use-is-kit/references/migration-checklist.md
@@ -6,12 +6,12 @@ boundary safety, or type narrowing.
 ## Common conversions
 
 | Existing pattern                      | Typical is-kit form                                               |
-| ------------------------------------- | ----------------------------------------------------------------- | -------------------- | ----------------------------------------- |
+| ------------------------------------- | ----------------------------------------------------------------- |
 | `typeof value === 'string'`           | `isString(value)`                                                 |
 | `typeof value === 'number'`           | Choose `isNumber` or `isNumberPrimitive` by semantics             |
-| `value === null                       |                                                                   | value === undefined` | `isNil(value)`                            |
-| `value == null                        |                                                                   | guard(value)`        | `nullish(guard)` for a reusable guard     |
-| `guardA(value)                        |                                                                   | guardB(value)`       | `or(guardA, guardB)` for a reusable guard |
+| `value === null \|\| value === undefined` | `isNil(value)`                                               |
+| `value == null \|\| guard(value)`    | `nullish(guard)` for a reusable guard                              |
+| `guardA(value) \|\| guardB(value)`   | `or(guardA, guardB)` for a reusable guard                          |
 | `base(value) && condition(value)`     | `and(base, refinement)` for a reusable guard                      |
 | Repeated literal comparisons          | `oneOfValues(...)`                                                |
 | Handwritten array `.every(...)` guard | `arrayOf(elementGuard)`                                           |

--- a/plugins/is-kit/skills/use-is-kit/references/migration-checklist.md
+++ b/plugins/is-kit/skills/use-is-kit/references/migration-checklist.md
@@ -1,0 +1,76 @@
+# Migration checklist
+
+Replace manual runtime checks only when the result improves reuse, composition,
+boundary safety, or type narrowing.
+
+## Common conversions
+
+| Existing pattern                      | Typical is-kit form                                               |
+| ------------------------------------- | ----------------------------------------------------------------- | -------------------- | ----------------------------------------- |
+| `typeof value === 'string'`           | `isString(value)`                                                 |
+| `typeof value === 'number'`           | Choose `isNumber` or `isNumberPrimitive` by semantics             |
+| `value === null                       |                                                                   | value === undefined` | `isNil(value)`                            |
+| `value == null                        |                                                                   | guard(value)`        | `nullish(guard)` for a reusable guard     |
+| `guardA(value)                        |                                                                   | guardB(value)`       | `or(guardA, guardB)` for a reusable guard |
+| `base(value) && condition(value)`     | `and(base, refinement)` for a reusable guard                      |
+| Repeated literal comparisons          | `oneOfValues(...)`                                                |
+| Handwritten array `.every(...)` guard | `arrayOf(elementGuard)`                                           |
+| Handwritten object-shape predicate    | `struct(...)` or `typedStruct<T>()(...)`                          |
+| `JSON.parse(...) as T`                | `safeJsonParse(text, guard)` or decode to `unknown` then validate |
+| `input as T` after manual checks      | Narrow with a guard and remove the assertion                      |
+
+## Preserve intent
+
+Before replacing a check, identify whether it is:
+
+- reusable type validation;
+- a local control-flow condition;
+- runtime/platform feature detection;
+- business policy rather than type validation;
+- coercion or transformation rather than validation.
+
+Do not convert environment checks such as `typeof window`, `typeof process`, or
+optional-global detection. Do not disguise business policy as a generic type
+guard. Do not replace validation libraries that provide transformations or
+structured errors unless the task explicitly changes that contract.
+
+## Respect project boundaries
+
+If the repository centralizes `is-kit` imports:
+
+1. Search the boundary's exports first.
+2. Add the smallest missing export or composed guard there.
+3. Import through the boundary everywhere else.
+4. Verify no new direct imports escaped the boundary.
+
+If no boundary exists, use direct package imports. Do not introduce an
+abstraction layer as an incidental migration change.
+
+Place single-consumer payload schemas next to their consumer. Put reusable,
+domain-free guards in the project's shared guard location. Put domain decisions
+in the owning domain module.
+
+## Keep narrowing stable
+
+Indexed and mutable property access can lose refinements. Extract the property
+before validating it:
+
+```ts
+const accessToken = body.accessToken;
+if (!isNonEmptyString(accessToken)) return null;
+
+// accessToken is string here.
+return accessToken;
+```
+
+Prefer this over asserting the property type after the guard.
+
+## Verify the migration
+
+- Search again for the targeted manual pattern.
+- Confirm changed imports follow the project convention.
+- Exercise accepted, rejected, and wrong-type inputs.
+- Check missing, optional, and extra keys for object schemas.
+- Run the repository's relevant unit tests and typecheck.
+- Run lint and formatting only at the scope the repository supports.
+- Review the diff and remove unrelated formatting changes.

--- a/plugins/is-kit/skills/use-is-kit/references/object-validation.md
+++ b/plugins/is-kit/skills/use-is-kit/references/object-validation.md
@@ -1,0 +1,126 @@
+# Object and boundary validation
+
+Validate object shapes at untrusted boundaries such as decoded JSON, network
+responses, storage, messages, environment-derived data, and third-party input.
+
+## Choose `typedStruct` or `struct`
+
+| Situation                                                                      | Choice                                               |
+| ------------------------------------------------------------------------------ | ---------------------------------------------------- |
+| A trustworthy target type exists and the whole contract must stay synchronized | `typedStruct<T>()(...)`                              |
+| No target type exists                                                          | `struct(...)`                                        |
+| The declared type disagrees with observed runtime data                         | `struct(...)`, with a concise reason near the schema |
+| Only a projection of a larger payload is consumed                              | `struct(...)`                                        |
+| Adding any target key must force schema maintenance                            | `typedStruct<T>()(...)`                              |
+
+Do not use `typedStruct` merely to assign a preferred output type. It is a
+compile-time synchronization contract: all required and optional target keys
+must be declared, incompatible guards are rejected, and extra schema keys are
+rejected.
+
+```ts
+import { isNumber, isString, optionalKey, typedStruct } from 'is-kit';
+
+type User = {
+  id: number;
+  displayName?: string;
+};
+
+const isUser = typedStruct<User>()({
+  id: isNumber,
+  displayName: optionalKey(isString)
+});
+```
+
+Use `struct` when the guard intentionally defines or projects the runtime
+shape:
+
+```ts
+import { isNumber, safeParse, struct } from 'is-kit';
+
+const isActorProjection = struct({
+  id: isNumber,
+  organization: struct({ id: isNumber })
+});
+
+export const parseActor = (input: unknown) => {
+  const parsed = safeParse(isActorProjection, input);
+  if (!parsed.valid) return null;
+
+  return {
+    actorId: parsed.value.id,
+    organizationId: parsed.value.organization.id
+  };
+};
+```
+
+When a declared/generated type conflicts with runtime data, do not cast the
+payload to the declared type. Validate the runtime projection actually used and
+record why it intentionally differs.
+
+## Key presence and value optionality
+
+Schema keys are required unless wrapped in `optionalKey`.
+
+```ts
+import { isString, optional, optionalKey, struct } from 'is-kit';
+
+const mayBeMissing = struct({
+  label: optionalKey(isString)
+});
+
+const mustExistButMayBeUndefined = struct({
+  label: optional(isString)
+});
+```
+
+These contracts differ:
+
+- `optionalKey(isString)`: the key may be absent; when present, it must contain
+  a string.
+- `optional(isString)`: the key must exist; its value may be a string or
+  `undefined`.
+- `optionalKey(optional(isString))`: the key may be absent or contain a string
+  or `undefined`.
+
+## Extra keys and plain objects
+
+`struct` and `typedStruct` accept schema-external keys by default. Keep this
+forward-compatible behavior for most API responses. Use `{ exact: true }` only
+when extra own enumerable string keys violate the contract.
+
+```ts
+const isExactPoint = struct({ x: isNumber, y: isNumber }, { exact: true });
+```
+
+These builders validate plain objects. Do not use them for arrays, `Date`,
+`Error`, maps, sets, or class instances. Prefer the matching built-in or
+collection guard, or use `isInstanceOf` for a project class when appropriate.
+
+## Consume validated values
+
+Call a guard directly for control flow:
+
+```ts
+if (!isUser(input)) return null;
+return input.id;
+```
+
+Use `safeParse` when a tagged result makes the value flow clearer:
+
+```ts
+const parsed = safeParse(isUser, input);
+if (!parsed.valid) return null;
+return parsed.value.id;
+```
+
+Avoid validating a payload and then continuing to read from the original
+`unknown` variable or an asserted alias.
+
+## Partial recovery
+
+Do not require an entire object to be valid when the product intentionally
+recovers independent fields. Validate the outer value as a record/plain object,
+extract each field into a local constant, and guard fields independently.
+Document this as partial recovery so a later refactor does not accidentally
+turn it into all-or-nothing validation.


### PR DESCRIPTION
## Summary

Add Codex Marketplace skill.

<!-- A brief summary of the changes -->

## Description

- add an `is-kit` plugin to the repository-scoped Codex Marketplace
- add the reusable English `use-is-kit` skill and references for guard selection, object validation, and migrations
- document the Marketplace plugin as the primary AI-agent distribution channel

<!-- A detailed explanation of the changes, including why they are needed -->
