### PR TITLE
docs: add API reference metadata

### DIFF
--- a/docs/app/api-reference/assert/page.tsx
+++ b/docs/app/api-reference/assert/page.tsx
@@ -3,6 +3,9 @@ import { CodeBlock } from '@/components/code/code-block';
 import { Heading } from '@/components/ui/heading';
 import { Paragraph } from '@/components/ui/paragraph';
 import { Stack } from '@/components/ui/stack';
+import { createApiMetadata } from '@/lib/api-metadata';
+
+export const metadata = createApiMetadata('/api-reference/assert');
 
 const sampleGuardAssert = `import { assert, isString } from 'is-kit';
 

--- a/docs/app/api-reference/assert/page.tsx
+++ b/docs/app/api-reference/assert/page.tsx
@@ -3,9 +3,9 @@ import { CodeBlock } from '@/components/code/code-block';
 import { Heading } from '@/components/ui/heading';
 import { Paragraph } from '@/components/ui/paragraph';
 import { Stack } from '@/components/ui/stack';
-import { createApiMetadata } from '@/lib/api-metadata';
+import { API_REFERENCE_PATHS, createApiMetadata } from '@/lib/api-metadata';
 
-export const metadata = createApiMetadata('/api-reference/assert');
+export const metadata = createApiMetadata(API_REFERENCE_PATHS.assert);
 
 const sampleGuardAssert = `import { assert, isString } from 'is-kit';
 
@@ -66,7 +66,7 @@ export default function AssertPage() {
         </Stack>
         <CodeBlock language='ts' code={sampleRefineAssert} />
       </Stack>
-      <ApiReferencePager currentHref='/api-reference/assert' />
+      <ApiReferencePager currentHref={API_REFERENCE_PATHS.assert} />
     </Stack>
   );
 }

--- a/docs/app/api-reference/combinators/array-of/page.tsx
+++ b/docs/app/api-reference/combinators/array-of/page.tsx
@@ -3,6 +3,11 @@ import { CodeBlock } from '@/components/code/code-block';
 import { Heading } from '@/components/ui/heading';
 import { Paragraph } from '@/components/ui/paragraph';
 import { Stack } from '@/components/ui/stack';
+import { createApiMetadata } from '@/lib/api-metadata';
+
+export const metadata = createApiMetadata(
+  '/api-reference/combinators/array-of'
+);
 
 const sample = `import { arrayOf, nonEmptyArrayOf, isString } from 'is-kit';
 

--- a/docs/app/api-reference/combinators/array-of/page.tsx
+++ b/docs/app/api-reference/combinators/array-of/page.tsx
@@ -3,11 +3,9 @@ import { CodeBlock } from '@/components/code/code-block';
 import { Heading } from '@/components/ui/heading';
 import { Paragraph } from '@/components/ui/paragraph';
 import { Stack } from '@/components/ui/stack';
-import { createApiMetadata } from '@/lib/api-metadata';
+import { API_REFERENCE_PATHS, createApiMetadata } from '@/lib/api-metadata';
 
-export const metadata = createApiMetadata(
-  '/api-reference/combinators/array-of'
-);
+export const metadata = createApiMetadata(API_REFERENCE_PATHS.arrayOf);
 
 const sample = `import { arrayOf, nonEmptyArrayOf, isString } from 'is-kit';
 
@@ -32,7 +30,7 @@ export default function ArrayOfPage() {
         </Stack>
         <CodeBlock code={sample} language='ts' />
       </Stack>
-      <ApiReferencePager currentHref='/api-reference/combinators/array-of' />
+      <ApiReferencePager currentHref={API_REFERENCE_PATHS.arrayOf} />
     </Stack>
   );
 }

--- a/docs/app/api-reference/combinators/map-of/page.tsx
+++ b/docs/app/api-reference/combinators/map-of/page.tsx
@@ -3,6 +3,9 @@ import { CodeBlock } from '@/components/code/code-block';
 import { Heading } from '@/components/ui/heading';
 import { Paragraph } from '@/components/ui/paragraph';
 import { Stack } from '@/components/ui/stack';
+import { createApiMetadata } from '@/lib/api-metadata';
+
+export const metadata = createApiMetadata('/api-reference/combinators/map-of');
 
 const sample = `import { mapOf, isString, isNumber } from 'is-kit';
 

--- a/docs/app/api-reference/combinators/map-of/page.tsx
+++ b/docs/app/api-reference/combinators/map-of/page.tsx
@@ -3,9 +3,9 @@ import { CodeBlock } from '@/components/code/code-block';
 import { Heading } from '@/components/ui/heading';
 import { Paragraph } from '@/components/ui/paragraph';
 import { Stack } from '@/components/ui/stack';
-import { createApiMetadata } from '@/lib/api-metadata';
+import { API_REFERENCE_PATHS, createApiMetadata } from '@/lib/api-metadata';
 
-export const metadata = createApiMetadata('/api-reference/combinators/map-of');
+export const metadata = createApiMetadata(API_REFERENCE_PATHS.mapOf);
 
 const sample = `import { mapOf, isString, isNumber } from 'is-kit';
 
@@ -25,7 +25,7 @@ export default function MapOfPage() {
         </Stack>
         <CodeBlock code={sample} language='ts' />
       </Stack>
-      <ApiReferencePager currentHref='/api-reference/combinators/map-of' />
+      <ApiReferencePager currentHref={API_REFERENCE_PATHS.mapOf} />
     </Stack>
   );
 }

--- a/docs/app/api-reference/combinators/one-of-values/page.tsx
+++ b/docs/app/api-reference/combinators/one-of-values/page.tsx
@@ -3,6 +3,11 @@ import { CodeBlock } from '@/components/code/code-block';
 import { Heading } from '@/components/ui/heading';
 import { Paragraph } from '@/components/ui/paragraph';
 import { Stack } from '@/components/ui/stack';
+import { createApiMetadata } from '@/lib/api-metadata';
+
+export const metadata = createApiMetadata(
+  '/api-reference/combinators/one-of-values'
+);
 
 const sample = `import { oneOfValues } from 'is-kit';
 

--- a/docs/app/api-reference/combinators/one-of-values/page.tsx
+++ b/docs/app/api-reference/combinators/one-of-values/page.tsx
@@ -3,11 +3,9 @@ import { CodeBlock } from '@/components/code/code-block';
 import { Heading } from '@/components/ui/heading';
 import { Paragraph } from '@/components/ui/paragraph';
 import { Stack } from '@/components/ui/stack';
-import { createApiMetadata } from '@/lib/api-metadata';
+import { API_REFERENCE_PATHS, createApiMetadata } from '@/lib/api-metadata';
 
-export const metadata = createApiMetadata(
-  '/api-reference/combinators/one-of-values'
-);
+export const metadata = createApiMetadata(API_REFERENCE_PATHS.oneOfValues);
 
 const sample = `import { oneOfValues } from 'is-kit';
 
@@ -27,7 +25,7 @@ export default function OneOfValuesPage() {
         </Stack>
         <CodeBlock code={sample} language='ts' />
       </Stack>
-      <ApiReferencePager currentHref='/api-reference/combinators/one-of-values' />
+      <ApiReferencePager currentHref={API_REFERENCE_PATHS.oneOfValues} />
     </Stack>
   );
 }

--- a/docs/app/api-reference/combinators/one-of/page.tsx
+++ b/docs/app/api-reference/combinators/one-of/page.tsx
@@ -3,6 +3,9 @@ import { CodeBlock } from '@/components/code/code-block';
 import { Heading } from '@/components/ui/heading';
 import { Paragraph } from '@/components/ui/paragraph';
 import { Stack } from '@/components/ui/stack';
+import { createApiMetadata } from '@/lib/api-metadata';
+
+export const metadata = createApiMetadata('/api-reference/combinators/one-of');
 
 const sample = `import { oneOf, isString, isNumber } from 'is-kit';
 

--- a/docs/app/api-reference/combinators/one-of/page.tsx
+++ b/docs/app/api-reference/combinators/one-of/page.tsx
@@ -3,9 +3,9 @@ import { CodeBlock } from '@/components/code/code-block';
 import { Heading } from '@/components/ui/heading';
 import { Paragraph } from '@/components/ui/paragraph';
 import { Stack } from '@/components/ui/stack';
-import { createApiMetadata } from '@/lib/api-metadata';
+import { API_REFERENCE_PATHS, createApiMetadata } from '@/lib/api-metadata';
 
-export const metadata = createApiMetadata('/api-reference/combinators/one-of');
+export const metadata = createApiMetadata(API_REFERENCE_PATHS.oneOf);
 
 const sample = `import { oneOf, isString, isNumber } from 'is-kit';
 
@@ -27,7 +27,7 @@ export default function OneOfPage() {
         </Stack>
         <CodeBlock code={sample} language='ts' />
       </Stack>
-      <ApiReferencePager currentHref='/api-reference/combinators/one-of' />
+      <ApiReferencePager currentHref={API_REFERENCE_PATHS.oneOf} />
     </Stack>
   );
 }

--- a/docs/app/api-reference/combinators/record-of/page.tsx
+++ b/docs/app/api-reference/combinators/record-of/page.tsx
@@ -3,11 +3,9 @@ import { CodeBlock } from '@/components/code/code-block';
 import { Heading } from '@/components/ui/heading';
 import { Paragraph } from '@/components/ui/paragraph';
 import { Stack } from '@/components/ui/stack';
-import { createApiMetadata } from '@/lib/api-metadata';
+import { API_REFERENCE_PATHS, createApiMetadata } from '@/lib/api-metadata';
 
-export const metadata = createApiMetadata(
-  '/api-reference/combinators/record-of'
-);
+export const metadata = createApiMetadata(API_REFERENCE_PATHS.recordOf);
 
 const sample = `import { recordOf, isString, isNumber } from 'is-kit';
 
@@ -27,7 +25,7 @@ export default function RecordOfPage() {
         </Stack>
         <CodeBlock code={sample} language='ts' />
       </Stack>
-      <ApiReferencePager currentHref='/api-reference/combinators/record-of' />
+      <ApiReferencePager currentHref={API_REFERENCE_PATHS.recordOf} />
     </Stack>
   );
 }

--- a/docs/app/api-reference/combinators/record-of/page.tsx
+++ b/docs/app/api-reference/combinators/record-of/page.tsx
@@ -3,6 +3,11 @@ import { CodeBlock } from '@/components/code/code-block';
 import { Heading } from '@/components/ui/heading';
 import { Paragraph } from '@/components/ui/paragraph';
 import { Stack } from '@/components/ui/stack';
+import { createApiMetadata } from '@/lib/api-metadata';
+
+export const metadata = createApiMetadata(
+  '/api-reference/combinators/record-of'
+);
 
 const sample = `import { recordOf, isString, isNumber } from 'is-kit';
 

--- a/docs/app/api-reference/combinators/set-of/page.tsx
+++ b/docs/app/api-reference/combinators/set-of/page.tsx
@@ -3,6 +3,9 @@ import { CodeBlock } from '@/components/code/code-block';
 import { Heading } from '@/components/ui/heading';
 import { Paragraph } from '@/components/ui/paragraph';
 import { Stack } from '@/components/ui/stack';
+import { createApiMetadata } from '@/lib/api-metadata';
+
+export const metadata = createApiMetadata('/api-reference/combinators/set-of');
 
 const sample = `import { setOf, isString } from 'is-kit';
 

--- a/docs/app/api-reference/combinators/set-of/page.tsx
+++ b/docs/app/api-reference/combinators/set-of/page.tsx
@@ -3,9 +3,9 @@ import { CodeBlock } from '@/components/code/code-block';
 import { Heading } from '@/components/ui/heading';
 import { Paragraph } from '@/components/ui/paragraph';
 import { Stack } from '@/components/ui/stack';
-import { createApiMetadata } from '@/lib/api-metadata';
+import { API_REFERENCE_PATHS, createApiMetadata } from '@/lib/api-metadata';
 
-export const metadata = createApiMetadata('/api-reference/combinators/set-of');
+export const metadata = createApiMetadata(API_REFERENCE_PATHS.setOf);
 
 const sample = `import { setOf, isString } from 'is-kit';
 
@@ -25,7 +25,7 @@ export default function SetOfPage() {
         </Stack>
         <CodeBlock code={sample} language='ts' />
       </Stack>
-      <ApiReferencePager currentHref='/api-reference/combinators/set-of' />
+      <ApiReferencePager currentHref={API_REFERENCE_PATHS.setOf} />
     </Stack>
   );
 }

--- a/docs/app/api-reference/combinators/struct/page.tsx
+++ b/docs/app/api-reference/combinators/struct/page.tsx
@@ -3,9 +3,9 @@ import { CodeBlock } from '@/components/code/code-block';
 import { Heading } from '@/components/ui/heading';
 import { Paragraph } from '@/components/ui/paragraph';
 import { Stack } from '@/components/ui/stack';
-import { createApiMetadata } from '@/lib/api-metadata';
+import { API_REFERENCE_PATHS, createApiMetadata } from '@/lib/api-metadata';
 
-export const metadata = createApiMetadata('/api-reference/combinators/struct');
+export const metadata = createApiMetadata(API_REFERENCE_PATHS.struct);
 
 const sample = `import {
   arrayOf,
@@ -77,7 +77,7 @@ export default function StructPage() {
         </Stack>
         <CodeBlock code={sample} language='ts' />
       </Stack>
-      <ApiReferencePager currentHref='/api-reference/combinators/struct' />
+      <ApiReferencePager currentHref={API_REFERENCE_PATHS.struct} />
     </Stack>
   );
 }

--- a/docs/app/api-reference/combinators/struct/page.tsx
+++ b/docs/app/api-reference/combinators/struct/page.tsx
@@ -3,6 +3,9 @@ import { CodeBlock } from '@/components/code/code-block';
 import { Heading } from '@/components/ui/heading';
 import { Paragraph } from '@/components/ui/paragraph';
 import { Stack } from '@/components/ui/stack';
+import { createApiMetadata } from '@/lib/api-metadata';
+
+export const metadata = createApiMetadata('/api-reference/combinators/struct');
 
 const sample = `import {
   arrayOf,

--- a/docs/app/api-reference/combinators/tuple-of/page.tsx
+++ b/docs/app/api-reference/combinators/tuple-of/page.tsx
@@ -3,6 +3,11 @@ import { CodeBlock } from '@/components/code/code-block';
 import { Heading } from '@/components/ui/heading';
 import { Paragraph } from '@/components/ui/paragraph';
 import { Stack } from '@/components/ui/stack';
+import { createApiMetadata } from '@/lib/api-metadata';
+
+export const metadata = createApiMetadata(
+  '/api-reference/combinators/tuple-of'
+);
 
 const sample = `import { tupleOf, isString, isNumber } from 'is-kit';
 

--- a/docs/app/api-reference/combinators/tuple-of/page.tsx
+++ b/docs/app/api-reference/combinators/tuple-of/page.tsx
@@ -3,11 +3,9 @@ import { CodeBlock } from '@/components/code/code-block';
 import { Heading } from '@/components/ui/heading';
 import { Paragraph } from '@/components/ui/paragraph';
 import { Stack } from '@/components/ui/stack';
-import { createApiMetadata } from '@/lib/api-metadata';
+import { API_REFERENCE_PATHS, createApiMetadata } from '@/lib/api-metadata';
 
-export const metadata = createApiMetadata(
-  '/api-reference/combinators/tuple-of'
-);
+export const metadata = createApiMetadata(API_REFERENCE_PATHS.tupleOf);
 
 const sample = `import { tupleOf, isString, isNumber } from 'is-kit';
 
@@ -28,7 +26,7 @@ export default function TupleOfPage() {
         </Stack>
         <CodeBlock code={sample} language='ts' />
       </Stack>
-      <ApiReferencePager currentHref='/api-reference/combinators/tuple-of' />
+      <ApiReferencePager currentHref={API_REFERENCE_PATHS.tupleOf} />
     </Stack>
   );
 }

--- a/docs/app/api-reference/combinators/typed-struct/page.tsx
+++ b/docs/app/api-reference/combinators/typed-struct/page.tsx
@@ -3,11 +3,9 @@ import { CodeBlock } from '@/components/code/code-block';
 import { Heading } from '@/components/ui/heading';
 import { Paragraph } from '@/components/ui/paragraph';
 import { Stack } from '@/components/ui/stack';
-import { createApiMetadata } from '@/lib/api-metadata';
+import { API_REFERENCE_PATHS, createApiMetadata } from '@/lib/api-metadata';
 
-export const metadata = createApiMetadata(
-  '/api-reference/combinators/typed-struct'
-);
+export const metadata = createApiMetadata(API_REFERENCE_PATHS.typedStruct);
 
 const sample = `import { isNumber, isString, optionalKey, typedStruct } from 'is-kit';
 
@@ -72,7 +70,7 @@ export default function TypedStructPage() {
         </Stack>
         <CodeBlock code={sample} language='ts' />
       </Stack>
-      <ApiReferencePager currentHref='/api-reference/combinators/typed-struct' />
+      <ApiReferencePager currentHref={API_REFERENCE_PATHS.typedStruct} />
     </Stack>
   );
 }

--- a/docs/app/api-reference/combinators/typed-struct/page.tsx
+++ b/docs/app/api-reference/combinators/typed-struct/page.tsx
@@ -3,6 +3,11 @@ import { CodeBlock } from '@/components/code/code-block';
 import { Heading } from '@/components/ui/heading';
 import { Paragraph } from '@/components/ui/paragraph';
 import { Stack } from '@/components/ui/stack';
+import { createApiMetadata } from '@/lib/api-metadata';
+
+export const metadata = createApiMetadata(
+  '/api-reference/combinators/typed-struct'
+);
 
 const sample = `import { isNumber, isString, optionalKey, typedStruct } from 'is-kit';
 

--- a/docs/app/api-reference/define/page.tsx
+++ b/docs/app/api-reference/define/page.tsx
@@ -3,6 +3,9 @@ import { CodeBlock } from '@/components/code/code-block';
 import { Heading } from '@/components/ui/heading';
 import { Paragraph } from '@/components/ui/paragraph';
 import { Stack } from '@/components/ui/stack';
+import { createApiMetadata } from '@/lib/api-metadata';
+
+export const metadata = createApiMetadata('/api-reference/define');
 
 const sample = `import { define, isString } from 'is-kit';
 

--- a/docs/app/api-reference/define/page.tsx
+++ b/docs/app/api-reference/define/page.tsx
@@ -3,9 +3,9 @@ import { CodeBlock } from '@/components/code/code-block';
 import { Heading } from '@/components/ui/heading';
 import { Paragraph } from '@/components/ui/paragraph';
 import { Stack } from '@/components/ui/stack';
-import { createApiMetadata } from '@/lib/api-metadata';
+import { API_REFERENCE_PATHS, createApiMetadata } from '@/lib/api-metadata';
 
-export const metadata = createApiMetadata('/api-reference/define');
+export const metadata = createApiMetadata(API_REFERENCE_PATHS.define);
 
 const sample = `import { define, isString } from 'is-kit';
 
@@ -30,7 +30,7 @@ export default function DefinePage() {
         </Stack>
         <CodeBlock code={sample} language='ts' />
       </Stack>
-      <ApiReferencePager currentHref='/api-reference/define' />
+      <ApiReferencePager currentHref={API_REFERENCE_PATHS.define} />
     </Stack>
   );
 }

--- a/docs/app/api-reference/equals/page.tsx
+++ b/docs/app/api-reference/equals/page.tsx
@@ -3,6 +3,9 @@ import { CodeBlock } from '@/components/code/code-block';
 import { Heading } from '@/components/ui/heading';
 import { Paragraph } from '@/components/ui/paragraph';
 import { Stack } from '@/components/ui/stack';
+import { createApiMetadata } from '@/lib/api-metadata';
+
+export const metadata = createApiMetadata('/api-reference/equals');
 
 const sample = `import { equals } from 'is-kit';
 

--- a/docs/app/api-reference/equals/page.tsx
+++ b/docs/app/api-reference/equals/page.tsx
@@ -3,9 +3,9 @@ import { CodeBlock } from '@/components/code/code-block';
 import { Heading } from '@/components/ui/heading';
 import { Paragraph } from '@/components/ui/paragraph';
 import { Stack } from '@/components/ui/stack';
-import { createApiMetadata } from '@/lib/api-metadata';
+import { API_REFERENCE_PATHS, createApiMetadata } from '@/lib/api-metadata';
 
-export const metadata = createApiMetadata('/api-reference/equals');
+export const metadata = createApiMetadata(API_REFERENCE_PATHS.equals);
 
 const sample = `import { equals } from 'is-kit';
 
@@ -62,7 +62,7 @@ export default function EqualsPage() {
         </Stack>
         <CodeBlock language='ts' code={sampleEqualsByAndKey} />
       </Stack>
-      <ApiReferencePager currentHref='/api-reference/equals' />
+      <ApiReferencePager currentHref={API_REFERENCE_PATHS.equals} />
     </Stack>
   );
 }

--- a/docs/app/api-reference/key/page.tsx
+++ b/docs/app/api-reference/key/page.tsx
@@ -3,9 +3,9 @@ import { CodeBlock } from '@/components/code/code-block';
 import { Heading } from '@/components/ui/heading';
 import { Paragraph } from '@/components/ui/paragraph';
 import { Stack } from '@/components/ui/stack';
-import { createApiMetadata } from '@/lib/api-metadata';
+import { API_REFERENCE_PATHS, createApiMetadata } from '@/lib/api-metadata';
 
-export const metadata = createApiMetadata('/api-reference/key');
+export const metadata = createApiMetadata(API_REFERENCE_PATHS.key);
 
 const sampleHasKey = `import { hasKey } from 'is-kit';
 
@@ -97,7 +97,7 @@ export default function KeyPage() {
         </Stack>
         <CodeBlock language='ts' code={sampleNarrowKeyTo} />
       </Stack>
-      <ApiReferencePager currentHref='/api-reference/key' />
+      <ApiReferencePager currentHref={API_REFERENCE_PATHS.key} />
     </Stack>
   );
 }

--- a/docs/app/api-reference/key/page.tsx
+++ b/docs/app/api-reference/key/page.tsx
@@ -3,6 +3,9 @@ import { CodeBlock } from '@/components/code/code-block';
 import { Heading } from '@/components/ui/heading';
 import { Paragraph } from '@/components/ui/paragraph';
 import { Stack } from '@/components/ui/stack';
+import { createApiMetadata } from '@/lib/api-metadata';
+
+export const metadata = createApiMetadata('/api-reference/key');
 
 const sampleHasKey = `import { hasKey } from 'is-kit';
 

--- a/docs/app/api-reference/logic/page.tsx
+++ b/docs/app/api-reference/logic/page.tsx
@@ -3,6 +3,9 @@ import { CodeBlock } from '@/components/code/code-block';
 import { Heading } from '@/components/ui/heading';
 import { Paragraph } from '@/components/ui/paragraph';
 import { Stack } from '@/components/ui/stack';
+import { createApiMetadata } from '@/lib/api-metadata';
+
+export const metadata = createApiMetadata('/api-reference/logic');
 
 const sample = `import { and, or, not, predicateToRefine, isString, isNumber } from 'is-kit';
 

--- a/docs/app/api-reference/logic/page.tsx
+++ b/docs/app/api-reference/logic/page.tsx
@@ -3,9 +3,9 @@ import { CodeBlock } from '@/components/code/code-block';
 import { Heading } from '@/components/ui/heading';
 import { Paragraph } from '@/components/ui/paragraph';
 import { Stack } from '@/components/ui/stack';
-import { createApiMetadata } from '@/lib/api-metadata';
+import { API_REFERENCE_PATHS, createApiMetadata } from '@/lib/api-metadata';
 
-export const metadata = createApiMetadata('/api-reference/logic');
+export const metadata = createApiMetadata(API_REFERENCE_PATHS.logic);
 
 const sample = `import { and, or, not, predicateToRefine, isString, isNumber } from 'is-kit';
 
@@ -103,7 +103,7 @@ export default function LogicPage() {
         </Stack>
         <CodeBlock language='ts' code={sampleGuardIn} />
       </Stack>
-      <ApiReferencePager currentHref='/api-reference/logic' />
+      <ApiReferencePager currentHref={API_REFERENCE_PATHS.logic} />
     </Stack>
   );
 }

--- a/docs/app/api-reference/nullish/page.tsx
+++ b/docs/app/api-reference/nullish/page.tsx
@@ -3,9 +3,9 @@ import { CodeBlock } from '@/components/code/code-block';
 import { Heading } from '@/components/ui/heading';
 import { Paragraph } from '@/components/ui/paragraph';
 import { Stack } from '@/components/ui/stack';
-import { createApiMetadata } from '@/lib/api-metadata';
+import { API_REFERENCE_PATHS, createApiMetadata } from '@/lib/api-metadata';
 
-export const metadata = createApiMetadata('/api-reference/nullish');
+export const metadata = createApiMetadata(API_REFERENCE_PATHS.nullish);
 
 const sample = `import {
   isNil,
@@ -66,7 +66,7 @@ export default function NullishPage() {
         </Stack>
         <CodeBlock code={sample} language='ts' />
       </Stack>
-      <ApiReferencePager currentHref='/api-reference/nullish' />
+      <ApiReferencePager currentHref={API_REFERENCE_PATHS.nullish} />
     </Stack>
   );
 }

--- a/docs/app/api-reference/nullish/page.tsx
+++ b/docs/app/api-reference/nullish/page.tsx
@@ -3,6 +3,9 @@ import { CodeBlock } from '@/components/code/code-block';
 import { Heading } from '@/components/ui/heading';
 import { Paragraph } from '@/components/ui/paragraph';
 import { Stack } from '@/components/ui/stack';
+import { createApiMetadata } from '@/lib/api-metadata';
+
+export const metadata = createApiMetadata('/api-reference/nullish');
 
 const sample = `import {
   isNil,

--- a/docs/app/api-reference/object/page.tsx
+++ b/docs/app/api-reference/object/page.tsx
@@ -3,6 +3,9 @@ import { CodeBlock } from '@/components/code/code-block';
 import { Heading } from '@/components/ui/heading';
 import { Paragraph } from '@/components/ui/paragraph';
 import { Stack } from '@/components/ui/stack';
+import { createApiMetadata } from '@/lib/api-metadata';
+
+export const metadata = createApiMetadata('/api-reference/object');
 
 const sample = `import {
   isFunction,

--- a/docs/app/api-reference/object/page.tsx
+++ b/docs/app/api-reference/object/page.tsx
@@ -3,9 +3,9 @@ import { CodeBlock } from '@/components/code/code-block';
 import { Heading } from '@/components/ui/heading';
 import { Paragraph } from '@/components/ui/paragraph';
 import { Stack } from '@/components/ui/stack';
-import { createApiMetadata } from '@/lib/api-metadata';
+import { API_REFERENCE_PATHS, createApiMetadata } from '@/lib/api-metadata';
 
-export const metadata = createApiMetadata('/api-reference/object');
+export const metadata = createApiMetadata(API_REFERENCE_PATHS.object);
 
 const sample = `import {
   isFunction,
@@ -87,7 +87,7 @@ export default function ObjectPage() {
         </Stack>
         <CodeBlock code={sample} language='ts' />
       </Stack>
-      <ApiReferencePager currentHref='/api-reference/object' />
+      <ApiReferencePager currentHref={API_REFERENCE_PATHS.object} />
     </Stack>
   );
 }

--- a/docs/app/api-reference/page.tsx
+++ b/docs/app/api-reference/page.tsx
@@ -9,6 +9,9 @@ import { Heading } from '@/components/ui/heading';
 import { Paragraph } from '@/components/ui/paragraph';
 import { Stack } from '@/components/ui/stack';
 import { API_ITEMS } from '@/constants/api-items';
+import { createApiMetadata } from '@/lib/api-metadata';
+
+export const metadata = createApiMetadata('/api-reference');
 
 export default function ApiIndexPage() {
   const items = API_ITEMS;

--- a/docs/app/api-reference/page.tsx
+++ b/docs/app/api-reference/page.tsx
@@ -9,9 +9,9 @@ import { Heading } from '@/components/ui/heading';
 import { Paragraph } from '@/components/ui/paragraph';
 import { Stack } from '@/components/ui/stack';
 import { API_ITEMS } from '@/constants/api-items';
-import { createApiMetadata } from '@/lib/api-metadata';
+import { API_REFERENCE_PATHS, createApiMetadata } from '@/lib/api-metadata';
 
-export const metadata = createApiMetadata('/api-reference');
+export const metadata = createApiMetadata(API_REFERENCE_PATHS.index);
 
 export default function ApiIndexPage() {
   const items = API_ITEMS;

--- a/docs/app/api-reference/parse/page.tsx
+++ b/docs/app/api-reference/parse/page.tsx
@@ -3,6 +3,9 @@ import { CodeBlock } from '@/components/code/code-block';
 import { Heading } from '@/components/ui/heading';
 import { Paragraph } from '@/components/ui/paragraph';
 import { Stack } from '@/components/ui/stack';
+import { createApiMetadata } from '@/lib/api-metadata';
+
+export const metadata = createApiMetadata('/api-reference/parse');
 
 const sample = `import { safeJsonParse, safeParse, safeParseWith, predicateToRefine, and, typedStruct, isString, isNumber } from 'is-kit';
 

--- a/docs/app/api-reference/parse/page.tsx
+++ b/docs/app/api-reference/parse/page.tsx
@@ -3,9 +3,9 @@ import { CodeBlock } from '@/components/code/code-block';
 import { Heading } from '@/components/ui/heading';
 import { Paragraph } from '@/components/ui/paragraph';
 import { Stack } from '@/components/ui/stack';
-import { createApiMetadata } from '@/lib/api-metadata';
+import { API_REFERENCE_PATHS, createApiMetadata } from '@/lib/api-metadata';
 
-export const metadata = createApiMetadata('/api-reference/parse');
+export const metadata = createApiMetadata(API_REFERENCE_PATHS.parse);
 
 const sample = `import { safeJsonParse, safeParse, safeParseWith, predicateToRefine, and, typedStruct, isString, isNumber } from 'is-kit';
 
@@ -37,7 +37,7 @@ export default function ParsePage() {
         </Stack>
         <CodeBlock code={sample} language='ts' />
       </Stack>
-      <ApiReferencePager currentHref='/api-reference/parse' />
+      <ApiReferencePager currentHref={API_REFERENCE_PATHS.parse} />
     </Stack>
   );
 }

--- a/docs/app/api-reference/predicate/page.tsx
+++ b/docs/app/api-reference/predicate/page.tsx
@@ -3,6 +3,9 @@ import { CodeBlock } from '@/components/code/code-block';
 import { Heading } from '@/components/ui/heading';
 import { Paragraph } from '@/components/ui/paragraph';
 import { Stack } from '@/components/ui/stack';
+import { createApiMetadata } from '@/lib/api-metadata';
+
+export const metadata = createApiMetadata('/api-reference/predicate');
 
 const sample = `import { predicateToRefine, and, isNumber } from 'is-kit';
 

--- a/docs/app/api-reference/predicate/page.tsx
+++ b/docs/app/api-reference/predicate/page.tsx
@@ -3,9 +3,9 @@ import { CodeBlock } from '@/components/code/code-block';
 import { Heading } from '@/components/ui/heading';
 import { Paragraph } from '@/components/ui/paragraph';
 import { Stack } from '@/components/ui/stack';
-import { createApiMetadata } from '@/lib/api-metadata';
+import { API_REFERENCE_PATHS, createApiMetadata } from '@/lib/api-metadata';
 
-export const metadata = createApiMetadata('/api-reference/predicate');
+export const metadata = createApiMetadata(API_REFERENCE_PATHS.predicate);
 
 const sample = `import { predicateToRefine, and, isNumber } from 'is-kit';
 
@@ -59,7 +59,7 @@ export default function PredicatePage() {
         </Stack>
         <CodeBlock code={sampleTrueRefinement} language='ts' />
       </Stack>
-      <ApiReferencePager currentHref='/api-reference/predicate' />
+      <ApiReferencePager currentHref={API_REFERENCE_PATHS.predicate} />
     </Stack>
   );
 }

--- a/docs/app/api-reference/primitive/page.tsx
+++ b/docs/app/api-reference/primitive/page.tsx
@@ -3,6 +3,9 @@ import { CodeBlock } from '@/components/code/code-block';
 import { Heading } from '@/components/ui/heading';
 import { Paragraph } from '@/components/ui/paragraph';
 import { Stack } from '@/components/ui/stack';
+import { createApiMetadata } from '@/lib/api-metadata';
+
+export const metadata = createApiMetadata('/api-reference/primitive');
 
 const sample = `import {
   isString,

--- a/docs/app/api-reference/primitive/page.tsx
+++ b/docs/app/api-reference/primitive/page.tsx
@@ -3,9 +3,9 @@ import { CodeBlock } from '@/components/code/code-block';
 import { Heading } from '@/components/ui/heading';
 import { Paragraph } from '@/components/ui/paragraph';
 import { Stack } from '@/components/ui/stack';
-import { createApiMetadata } from '@/lib/api-metadata';
+import { API_REFERENCE_PATHS, createApiMetadata } from '@/lib/api-metadata';
 
-export const metadata = createApiMetadata('/api-reference/primitive');
+export const metadata = createApiMetadata(API_REFERENCE_PATHS.primitive);
 
 const sample = `import {
   isString,
@@ -81,7 +81,7 @@ export default function PrimitivePage() {
         </Stack>
         <CodeBlock code={sample} language='ts' />
       </Stack>
-      <ApiReferencePager currentHref='/api-reference/primitive' />
+      <ApiReferencePager currentHref={API_REFERENCE_PATHS.primitive} />
     </Stack>
   );
 }

--- a/docs/app/api-reference/types/page.tsx
+++ b/docs/app/api-reference/types/page.tsx
@@ -3,6 +3,9 @@ import { CodeBlock } from '@/components/code/code-block';
 import { Heading } from '@/components/ui/heading';
 import { Paragraph } from '@/components/ui/paragraph';
 import { Stack } from '@/components/ui/stack';
+import { createApiMetadata } from '@/lib/api-metadata';
+
+export const metadata = createApiMetadata('/api-reference/types');
 
 const sample = `import { isString, optionalKey, struct } from 'is-kit';
 import type {

--- a/docs/app/api-reference/types/page.tsx
+++ b/docs/app/api-reference/types/page.tsx
@@ -3,9 +3,9 @@ import { CodeBlock } from '@/components/code/code-block';
 import { Heading } from '@/components/ui/heading';
 import { Paragraph } from '@/components/ui/paragraph';
 import { Stack } from '@/components/ui/stack';
-import { createApiMetadata } from '@/lib/api-metadata';
+import { API_REFERENCE_PATHS, createApiMetadata } from '@/lib/api-metadata';
 
-export const metadata = createApiMetadata('/api-reference/types');
+export const metadata = createApiMetadata(API_REFERENCE_PATHS.types);
 
 const sample = `import { isString, optionalKey, struct } from 'is-kit';
 import type {
@@ -147,7 +147,7 @@ export default function TypesPage() {
         </Paragraph>
       </Stack>
 
-      <ApiReferencePager currentHref='/api-reference/types' />
+      <ApiReferencePager currentHref={API_REFERENCE_PATHS.types} />
     </Stack>
   );
 }

--- a/docs/app/layout.tsx
+++ b/docs/app/layout.tsx
@@ -7,6 +7,7 @@ import { apiSections } from '@/constants/api-sections';
 import {
   SITE_DESCRIPTION,
   SITE_OPEN_GRAPH,
+  SITE_SOCIAL_IMAGE,
   SITE_TITLE,
   SITE_URL
 } from '@/constants/site';
@@ -39,7 +40,7 @@ export const metadata: Metadata = {
     card: 'summary_large_image',
     title: SITE_TITLE,
     description: SITE_DESCRIPTION,
-    images: ['/iskit_logo1.svg']
+    images: [SITE_SOCIAL_IMAGE]
   }
 };
 

--- a/docs/constants/site.ts
+++ b/docs/constants/site.ts
@@ -7,12 +7,14 @@ export const SITE_TITLE = 'is-kit Docs — TypeScript Type Guard Toolkit';
 export const SITE_DESCRIPTION =
   'Documentation for is-kit, a lightweight, zero-dependency toolkit for building composable TypeScript type guards.';
 
+export const SITE_SOCIAL_IMAGE = '/iskit_logo1.svg';
+
 export const SITE_OPEN_GRAPH = {
   type: 'website',
   siteName: 'is-kit Docs',
   images: [
     {
-      url: '/iskit_logo1.svg',
+      url: SITE_SOCIAL_IMAGE,
       alt: 'is-kit logo'
     }
   ]

--- a/docs/lib/api-metadata.ts
+++ b/docs/lib/api-metadata.ts
@@ -1,0 +1,146 @@
+import type { Metadata } from 'next';
+import { SITE_OPEN_GRAPH, SITE_SOCIAL_IMAGE } from '@/constants/site';
+
+type ApiMetadataCopy = {
+  title: string;
+  description: string;
+};
+
+const API_METADATA = {
+  '/api-reference': {
+    title: 'TypeScript Type Guard API Reference | is-kit',
+    description:
+      'Browse is-kit APIs for building and composing TypeScript type guards, validating data at runtime, and narrowing unknown values.'
+  },
+  '/api-reference/define': {
+    title: 'define — Create TypeScript Type Guards | is-kit',
+    description:
+      'Create reusable TypeScript type guards from boolean predicates with define while preserving natural type narrowing.'
+  },
+  '/api-reference/equals': {
+    title: 'equals — Type-Safe Equality Guards | is-kit',
+    description:
+      'Create equality guards with equals, equalsBy, and equalsKey using exact Object.is semantics and TypeScript literal narrowing.'
+  },
+  '/api-reference/logic': {
+    title: 'and, or, not — Compose TypeScript Type Guards | is-kit',
+    description:
+      'Compose reusable TypeScript type guards with and, andAll, or, not, and guardIn while preserving precise narrowing.'
+  },
+  '/api-reference/parse': {
+    title: 'safeParse and safeJsonParse — Parse Unknown Values | is-kit',
+    description:
+      'Validate unknown values and decoded JSON with TypeScript type guards using safeParse, safeParseWith, and safeJsonParse.'
+  },
+  '/api-reference/assert': {
+    title: 'assert — TypeScript Assertion and Narrowing | is-kit',
+    description:
+      'Assert that an unknown value matches an is-kit guard, throw on failure, and narrow the value for subsequent TypeScript code.'
+  },
+  '/api-reference/nullish': {
+    title: 'isNil and isNotNil — Nullish Type Guards | is-kit',
+    description:
+      'Check and compose nullish values with isNil, isNotNil, nullable, optional, required, and nonNull TypeScript guards.'
+  },
+  '/api-reference/key': {
+    title: 'hasKey, hasKeys, and narrowKeyTo | is-kit',
+    description:
+      'Check object keys and narrow property values safely in TypeScript with hasKey, hasKeys, and narrowKeyTo.'
+  },
+  '/api-reference/primitive': {
+    title: 'Primitive Type Guards for TypeScript | is-kit',
+    description:
+      'Use isString, isNumber, isBoolean, isInteger, isNaN, isNil, and other zero-dependency primitive TypeScript guards.'
+  },
+  '/api-reference/object': {
+    title: 'Object and Built-In Type Guards for TypeScript | is-kit',
+    description:
+      'Check objects, arrays, dates, maps, sets, promises, typed arrays, URLs, and other JavaScript built-ins with type guards.'
+  },
+  '/api-reference/predicate': {
+    title: 'predicateToRefine — TypeScript Refinements | is-kit',
+    description:
+      'Convert boolean predicates into reusable TypeScript refinements and compose them with type guards for precise narrowing.'
+  },
+  '/api-reference/types': {
+    title: 'TypeScript Guard, Schema, and Parse Types | is-kit',
+    description:
+      'Explore the public is-kit types for predicates, guards, refinements, parsing results, schema inference, and reusable wrappers.'
+  },
+  '/api-reference/combinators/array-of': {
+    title: 'arrayOf — TypeScript Array Type Guard | is-kit',
+    description:
+      'Build reusable TypeScript guards for homogeneous and non-empty arrays by composing an element guard with arrayOf.'
+  },
+  '/api-reference/combinators/tuple-of': {
+    title: 'tupleOf — TypeScript Tuple Type Guard | is-kit',
+    description:
+      'Validate fixed-length TypeScript tuples with per-position guards while preserving precise tuple type inference.'
+  },
+  '/api-reference/combinators/set-of': {
+    title: 'setOf — TypeScript Set Type Guard | is-kit',
+    description:
+      'Build a reusable TypeScript guard that validates a Set and checks every value with a provided guard.'
+  },
+  '/api-reference/combinators/map-of': {
+    title: 'mapOf — TypeScript Map Type Guard | is-kit',
+    description:
+      'Build a reusable TypeScript guard that validates a Map and checks every key and value with composed guards.'
+  },
+  '/api-reference/combinators/one-of': {
+    title: 'oneOf — Compose Union Type Guards | is-kit',
+    description:
+      'Combine multiple TypeScript type guards into a reusable union guard that passes when any input guard matches.'
+  },
+  '/api-reference/combinators/record-of': {
+    title: 'recordOf — TypeScript Record Type Guard | is-kit',
+    description:
+      'Validate TypeScript records at runtime by composing guards for their enumerable keys and values with recordOf.'
+  },
+  '/api-reference/combinators/struct': {
+    title: 'struct — TypeScript Object Shape Guard | is-kit',
+    description:
+      'Build composable TypeScript object shape guards with required and optional keys, inferred types, and exact key checking.'
+  },
+  '/api-reference/combinators/typed-struct': {
+    title: 'typedStruct — Guard Existing TypeScript Types | is-kit',
+    description:
+      'Keep a hand-written runtime object guard aligned with an existing TypeScript type using typedStruct and field-level checks.'
+  },
+  '/api-reference/combinators/one-of-values': {
+    title: 'oneOfValues — TypeScript Literal Value Guard | is-kit',
+    description:
+      'Create a TypeScript guard for a set of literal values with exact equality and inferred literal union narrowing.'
+  }
+} as const satisfies Record<string, ApiMetadataCopy>;
+
+export type ApiReferencePath = keyof typeof API_METADATA;
+
+/**
+ * Build search and social metadata for an API reference route.
+ * @param path Canonical API reference path with registered metadata copy.
+ * @returns Metadata with page-specific titles, descriptions, and canonical URLs.
+ */
+export function createApiMetadata(path: ApiReferencePath): Metadata {
+  const { title, description } = API_METADATA[path];
+
+  return {
+    title,
+    description,
+    alternates: {
+      canonical: path
+    },
+    openGraph: {
+      ...SITE_OPEN_GRAPH,
+      title,
+      description,
+      url: path
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title,
+      description,
+      images: [SITE_SOCIAL_IMAGE]
+    }
+  };
+}

--- a/docs/lib/api-metadata.ts
+++ b/docs/lib/api-metadata.ts
@@ -6,115 +6,141 @@ type ApiMetadataCopy = {
   description: string;
 };
 
+/** Canonical paths for API reference routes with registered metadata. */
+export const API_REFERENCE_PATHS = {
+  index: '/api-reference',
+  define: '/api-reference/define',
+  equals: '/api-reference/equals',
+  logic: '/api-reference/logic',
+  parse: '/api-reference/parse',
+  assert: '/api-reference/assert',
+  nullish: '/api-reference/nullish',
+  key: '/api-reference/key',
+  primitive: '/api-reference/primitive',
+  object: '/api-reference/object',
+  predicate: '/api-reference/predicate',
+  types: '/api-reference/types',
+  arrayOf: '/api-reference/combinators/array-of',
+  tupleOf: '/api-reference/combinators/tuple-of',
+  setOf: '/api-reference/combinators/set-of',
+  mapOf: '/api-reference/combinators/map-of',
+  oneOf: '/api-reference/combinators/one-of',
+  recordOf: '/api-reference/combinators/record-of',
+  struct: '/api-reference/combinators/struct',
+  typedStruct: '/api-reference/combinators/typed-struct',
+  oneOfValues: '/api-reference/combinators/one-of-values'
+} as const;
+
+export type ApiReferencePath =
+  (typeof API_REFERENCE_PATHS)[keyof typeof API_REFERENCE_PATHS];
+
 const API_METADATA = {
-  '/api-reference': {
+  [API_REFERENCE_PATHS.index]: {
     title: 'TypeScript Type Guard API Reference | is-kit',
     description:
       'Browse is-kit APIs for building and composing TypeScript type guards, validating data at runtime, and narrowing unknown values.'
   },
-  '/api-reference/define': {
+  [API_REFERENCE_PATHS.define]: {
     title: 'define — Create TypeScript Type Guards | is-kit',
     description:
       'Create reusable TypeScript type guards from boolean predicates with define while preserving natural type narrowing.'
   },
-  '/api-reference/equals': {
+  [API_REFERENCE_PATHS.equals]: {
     title: 'equals — Type-Safe Equality Guards | is-kit',
     description:
       'Create equality guards with equals, equalsBy, and equalsKey using exact Object.is semantics and TypeScript literal narrowing.'
   },
-  '/api-reference/logic': {
+  [API_REFERENCE_PATHS.logic]: {
     title: 'and, or, not — Compose TypeScript Type Guards | is-kit',
     description:
       'Compose reusable TypeScript type guards with and, andAll, or, not, and guardIn while preserving precise narrowing.'
   },
-  '/api-reference/parse': {
+  [API_REFERENCE_PATHS.parse]: {
     title: 'safeParse and safeJsonParse — Parse Unknown Values | is-kit',
     description:
       'Validate unknown values and decoded JSON with TypeScript type guards using safeParse, safeParseWith, and safeJsonParse.'
   },
-  '/api-reference/assert': {
+  [API_REFERENCE_PATHS.assert]: {
     title: 'assert — TypeScript Assertion and Narrowing | is-kit',
     description:
       'Assert that an unknown value matches an is-kit guard, throw on failure, and narrow the value for subsequent TypeScript code.'
   },
-  '/api-reference/nullish': {
+  [API_REFERENCE_PATHS.nullish]: {
     title: 'isNil and isNotNil — Nullish Type Guards | is-kit',
     description:
       'Check and compose nullish values with isNil, isNotNil, nullable, optional, required, and nonNull TypeScript guards.'
   },
-  '/api-reference/key': {
+  [API_REFERENCE_PATHS.key]: {
     title: 'hasKey, hasKeys, and narrowKeyTo | is-kit',
     description:
       'Check object keys and narrow property values safely in TypeScript with hasKey, hasKeys, and narrowKeyTo.'
   },
-  '/api-reference/primitive': {
+  [API_REFERENCE_PATHS.primitive]: {
     title: 'Primitive Type Guards for TypeScript | is-kit',
     description:
       'Use isString, isNumber, isBoolean, isInteger, isNaN, isNil, and other zero-dependency primitive TypeScript guards.'
   },
-  '/api-reference/object': {
+  [API_REFERENCE_PATHS.object]: {
     title: 'Object and Built-In Type Guards for TypeScript | is-kit',
     description:
       'Check objects, arrays, dates, maps, sets, promises, typed arrays, URLs, and other JavaScript built-ins with type guards.'
   },
-  '/api-reference/predicate': {
+  [API_REFERENCE_PATHS.predicate]: {
     title: 'predicateToRefine — TypeScript Refinements | is-kit',
     description:
       'Convert boolean predicates into reusable TypeScript refinements and compose them with type guards for precise narrowing.'
   },
-  '/api-reference/types': {
+  [API_REFERENCE_PATHS.types]: {
     title: 'TypeScript Guard, Schema, and Parse Types | is-kit',
     description:
       'Explore the public is-kit types for predicates, guards, refinements, parsing results, schema inference, and reusable wrappers.'
   },
-  '/api-reference/combinators/array-of': {
+  [API_REFERENCE_PATHS.arrayOf]: {
     title: 'arrayOf — TypeScript Array Type Guard | is-kit',
     description:
       'Build reusable TypeScript guards for homogeneous and non-empty arrays by composing an element guard with arrayOf.'
   },
-  '/api-reference/combinators/tuple-of': {
+  [API_REFERENCE_PATHS.tupleOf]: {
     title: 'tupleOf — TypeScript Tuple Type Guard | is-kit',
     description:
       'Validate fixed-length TypeScript tuples with per-position guards while preserving precise tuple type inference.'
   },
-  '/api-reference/combinators/set-of': {
+  [API_REFERENCE_PATHS.setOf]: {
     title: 'setOf — TypeScript Set Type Guard | is-kit',
     description:
       'Build a reusable TypeScript guard that validates a Set and checks every value with a provided guard.'
   },
-  '/api-reference/combinators/map-of': {
+  [API_REFERENCE_PATHS.mapOf]: {
     title: 'mapOf — TypeScript Map Type Guard | is-kit',
     description:
       'Build a reusable TypeScript guard that validates a Map and checks every key and value with composed guards.'
   },
-  '/api-reference/combinators/one-of': {
+  [API_REFERENCE_PATHS.oneOf]: {
     title: 'oneOf — Compose Union Type Guards | is-kit',
     description:
       'Combine multiple TypeScript type guards into a reusable union guard that passes when any input guard matches.'
   },
-  '/api-reference/combinators/record-of': {
+  [API_REFERENCE_PATHS.recordOf]: {
     title: 'recordOf — TypeScript Record Type Guard | is-kit',
     description:
       'Validate TypeScript records at runtime by composing guards for their enumerable keys and values with recordOf.'
   },
-  '/api-reference/combinators/struct': {
+  [API_REFERENCE_PATHS.struct]: {
     title: 'struct — TypeScript Object Shape Guard | is-kit',
     description:
       'Build composable TypeScript object shape guards with required and optional keys, inferred types, and exact key checking.'
   },
-  '/api-reference/combinators/typed-struct': {
+  [API_REFERENCE_PATHS.typedStruct]: {
     title: 'typedStruct — Guard Existing TypeScript Types | is-kit',
     description:
       'Keep a hand-written runtime object guard aligned with an existing TypeScript type using typedStruct and field-level checks.'
   },
-  '/api-reference/combinators/one-of-values': {
+  [API_REFERENCE_PATHS.oneOfValues]: {
     title: 'oneOfValues — TypeScript Literal Value Guard | is-kit',
     description:
       'Create a TypeScript guard for a set of literal values with exact equality and inferred literal union narrowing.'
   }
-} as const satisfies Record<string, ApiMetadataCopy>;
-
-export type ApiReferencePath = keyof typeof API_METADATA;
+} as const satisfies Record<ApiReferencePath, ApiMetadataCopy>;
 
 /**
  * Build search and social metadata for an API reference route.


### PR DESCRIPTION
## Summary

Add API reference metadata.

<!-- A brief summary of the changes -->

## Description

Introduces `createApiMetadata` to generate titles, descriptions, canonical URLs, Open Graph data, and Twitter Card metadata for each API reference page.

API reference paths are defined in `API_REFERENCE_PATHS` and shared by the metadata registry, page metadata declarations, and pagers. The metadata registry is type-checked to prevent missing entries when new paths are added.

<!-- A detailed explanation of the changes, including why they are needed -->
