### PR TITLE
feat: add vlt installation support

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,3 +17,5 @@ jobs:
         run: mise run build
       - name: Smoke-test package artifact
         run: mise run test-package
+      - name: Smoke-test package artifact with vlt
+        run: mise run test-package-vlt

--- a/README.md
+++ b/README.md
@@ -73,11 +73,24 @@ bun add is-kit
 npm install is-kit
 # or
 yarn add is-kit
+# or
+vlt install is-kit
 ```
 
 ESM and CJS builds are available for npm consumers, and bundled types are included.
 
+vlt requires registry configuration before installing a package by name. Run
+`vlt setup` once if a registry has not been configured yet.
+
 ### JSR
+
+Install the JSR package with vlt:
+
+```bash
+vlt install jsr:@nyaomaru/is-kit
+```
+
+Or import it directly in runtimes that support `jsr:` specifiers:
 
 ```ts
 import { and, define, or } from 'jsr:@nyaomaru/is-kit';

--- a/docs/constants/docs.ts
+++ b/docs/constants/docs.ts
@@ -1,10 +1,11 @@
-export const INSTALL_TABS = ['pnpm', 'npm', 'yarn', 'bun'] as const;
+export const INSTALL_TABS = ['pnpm', 'npm', 'yarn', 'bun', 'vlt'] as const;
 export type InstallTab = (typeof INSTALL_TABS)[number];
 export const INSTALL_COMMANDS: Record<InstallTab, string> = {
   pnpm: 'pnpm add is-kit',
   npm: 'npm i is-kit',
   yarn: 'yarn add is-kit',
-  bun: 'bun add is-kit'
+  bun: 'bun add is-kit',
+  vlt: 'vlt install is-kit'
 };
 
 export const USAGE_TABS = [

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -14,6 +14,19 @@
 npm install is-kit
 ```
 
+```bash
+vlt install is-kit
+```
+
+vlt requires registry configuration before installing a package by name. Run
+`vlt setup` once if a registry has not been configured yet.
+
+Install the JSR package with vlt:
+
+```bash
+vlt install jsr:@nyaomaru/is-kit
+```
+
 ```ts
 import {
   isNotNil,

--- a/mise.toml
+++ b/mise.toml
@@ -37,6 +37,10 @@ run = "pnpm test:types"
 description = "Smoke-test the packed npm artifact"
 run = "pnpm test:package"
 
+[tasks.test-package-vlt]
+description = "Smoke-test the packed npm artifact with vlt"
+run = "pnpm test:package:vlt"
+
 [tasks.ci]
 description = "Run lint, build, runtime and type tests"
 depends = ["lint", "build", "test", "test-types"]

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "test": "jest",
     "test:types": "tsd",
     "test:package": "node tests/package-smoke.mjs",
+    "test:package:vlt": "node tests/vlt-package-smoke.mjs",
     "lint": "oxlint .",
     "format": "oxfmt .",
     "format:check": "oxfmt --check .",

--- a/tests/vlt-package-smoke.mjs
+++ b/tests/vlt-package-smoke.mjs
@@ -1,0 +1,97 @@
+import { execFileSync } from 'node:child_process';
+import {
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  rmSync,
+  writeFileSync
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const VLT_VERSION_SPEC = '1';
+const NPM_REGISTRY = 'https://registry.npmjs.org/';
+const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const temporaryRoot = mkdtempSync(join(tmpdir(), 'is-kit-vlt-smoke-'));
+const packageDirectory = join(temporaryRoot, 'package');
+const consumerDirectory = join(temporaryRoot, 'consumer');
+const npmCacheDirectory = join(temporaryRoot, 'npm-cache');
+const npmEnvironment = {
+  ...process.env,
+  npm_config_cache: npmCacheDirectory,
+  npm_config_ignore_scripts: 'true',
+  npm_config_update_notifier: 'false'
+};
+
+const run = (command, args, cwd = consumerDirectory) =>
+  execFileSync(command, args, {
+    cwd,
+    env: npmEnvironment,
+    stdio: 'inherit'
+  });
+
+const writeConsumerFile = (name, contents) =>
+  writeFileSync(join(consumerDirectory, name), contents);
+
+try {
+  mkdirSync(packageDirectory, { recursive: true });
+  mkdirSync(consumerDirectory, { recursive: true });
+
+  run('npm', ['pack', '--pack-destination', packageDirectory], repositoryRoot);
+  const [filename] = readdirSync(packageDirectory).filter((name) =>
+    name.endsWith('.tgz')
+  );
+  if (!filename) throw new Error('npm pack did not create a tarball');
+  const tarballPath = join(packageDirectory, filename);
+  // WHY: vlt 1.0.2 fails to unpack absolute local tarball paths but supports
+  // the documented relative-path form.
+  const tarballSpec = relative(consumerDirectory, tarballPath);
+
+  writeConsumerFile(
+    'package.json',
+    `${JSON.stringify({ private: true, type: 'module' }, null, 2)}\n`
+  );
+
+  run('npm', [
+    'exec',
+    '--yes',
+    `--package=vlt@${VLT_VERSION_SPEC}`,
+    '--',
+    'vlt',
+    `--registry=${NPM_REGISTRY}`,
+    'install',
+    tarballSpec
+  ]);
+
+  writeConsumerFile(
+    'esm-smoke.mjs',
+    `import assert from 'node:assert/strict';
+import { arrayOf, isString } from 'is-kit';
+
+assert.equal(isString('value'), true);
+assert.equal(arrayOf(isString)(['a', 'b']), true);
+assert.equal(arrayOf(isString)(['a', 1]), false);
+`
+  );
+
+  writeConsumerFile(
+    'cjs-smoke.cjs',
+    `const assert = require('node:assert/strict');
+const { arrayOf, isString } = require('is-kit');
+
+assert.equal(isString('value'), true);
+assert.equal(arrayOf(isString)(['a', 'b']), true);
+assert.equal(arrayOf(isString)(['a', 1]), false);
+`
+  );
+
+  run(process.execPath, ['esm-smoke.mjs']);
+  run(process.execPath, ['cjs-smoke.cjs']);
+
+  console.log(
+    `Package smoke test passed for ESM and CJS using vlt ${VLT_VERSION_SPEC}.x.`
+  );
+} finally {
+  rmSync(temporaryRoot, { recursive: true, force: true });
+}


### PR DESCRIPTION
## Summary

Add `vlt` installation support.

<!-- A brief summary of the changes -->

## Description

- add `vlt` installation commands for `npm` and `JSR` packages
- add a `vlt` v1 smoke test covering the packed artifact with ESM and CJS
- run the `vlt` package smoke test in PR CI

<!-- A detailed explanation of the changes, including why they are needed -->
