### PR TITLE
docs: add guide for keeping type guards in sync

### DIFF
--- a/.codex/skills/learn/LEARNED_INDEX.md
+++ b/.codex/skills/learn/LEARNED_INDEX.md
@@ -1,5 +1,6 @@
 # Learned Patterns
 
 - **[deprecate-public-api-before-major-removal](learned/deprecate-public-api-before-major-removal.md)** - Deprecate accidental runtime exports during the current major before removing only their public entry point in the next major.
+- **[keep-typed-schema-key-coverage-explicit](learned/keep-typed-schema-key-coverage-explicit.md)** - Match typed schema drift claims to the string-key coverage enforced by both mapped types and runtime enumeration.
 - **[model-transformations-as-decoders](learned/model-transformations-as-decoders.md)** - Model value-changing boundary conversions as ParseResult-returning decoder functions rather than type guards.
 - **[test-packed-artifacts-from-a-consumer-project](learned/test-packed-artifacts-from-a-consumer-project.md)** - Install the packed tarball in a temporary consumer to verify ESM, CommonJS, and declaration resolution before publishing.

--- a/.codex/skills/learn/learned/keep-typed-schema-key-coverage-explicit.md
+++ b/.codex/skills/learn/learned/keep-typed-schema-key-coverage-explicit.md
@@ -1,0 +1,96 @@
+# Keep Typed Schema Key Coverage Explicit
+
+**Captured:** 2026-08-16
+**Context:** Modeling a typed schema builder whose compile-time key coverage must match the keys its runtime validator can inspect.
+**Tags:** typescript, type-guards, typed-struct, object-keys, runtime-validation, tsd, documentation
+
+## Problem
+
+A typed schema helper can appear to detect every target-type change while its
+mapped type covers only a subset of `keyof T`. In `typedStruct`, the checked
+shape uses `Extract<..., string>`, so numeric and symbol properties are omitted:
+
+```ts
+type TypedStructShape<T extends object> = {
+  [K in Extract<RequiredObjectKeys<T>, string>]-?: Predicate<T[K]>;
+};
+```
+
+As a result, a target such as `{ 0: string }` can be paired with an empty field
+map. Adding a numeric or symbol property therefore does not produce the same
+drift error as adding a string-keyed property. The resulting guard has no schema
+entry for that target property and cannot validate it.
+
+This is also a runtime-design concern. `struct` builds its field entries with
+string-key enumeration, and exact mode follows `Object.keys(...)` semantics.
+Symbol keys are outside that contract. JavaScript coerces numeric object keys to
+strings at runtime, but `typedStruct` currently excludes numeric keys before a
+matching field can be declared.
+
+## Solution
+
+Keep compile-time claims no broader than the actual type and runtime key
+coverage:
+
+- Describe current `typedStruct` drift detection as applying to string-keyed
+  object shapes.
+- State explicitly that numeric and symbol target properties are not required
+  by `TypedStructShape` and are not validated by the resulting guard.
+- Apply the qualification consistently in guides, API reference pages, public
+  JSDoc, metadata, and README examples that describe drift detection.
+- Keep compile-time schema-key rejection separate from runtime extra-key
+  behavior. `{ exact: true }` controls extra own enumerable string keys in the
+  input; it does not add target-key coverage.
+
+Do not extend the mapped type alone. Supporting numeric keys would require an
+intentional normalization between TypeScript numeric keys and JavaScript string
+property keys. Supporting symbols would also require runtime enumeration and
+schema representation changes, such as moving beyond `for...in` and
+`Object.keys(...)` semantics.
+
+## Example
+
+```ts
+type NumericTarget = { 0: string };
+
+// Current limitation: the numeric target key is excluded from
+// TypedStructShape<NumericTarget>, so this compiles with no field declaration.
+const isNumericTarget = typedStruct<NumericTarget>()({});
+
+isNumericTarget({});
+// The guard cannot establish the target's numeric property at runtime.
+```
+
+If numeric or symbol support is added later, cover both sides of the contract:
+
+1. Add `tsd` assertions that missing required keys fail and compatible keys are
+   accepted.
+2. Add runtime tests proving those keys are inspected.
+3. Define how exact mode treats each key category.
+4. Remove the documentation limitation only after all three behaviors agree.
+
+## When To Use
+
+Use this pattern when a generic builder maps over `keyof T`, especially when it
+filters keys with `Extract`, key remapping, or a `string` constraint. Compare
+the resulting type-level key set with the runtime enumeration primitive before
+claiming exhaustive validation or drift detection.
+
+Verify similar changes with:
+
+```sh
+pnpm lint
+pnpm build
+pnpm test
+pnpm test:types
+```
+
+## Related Files
+
+- `src/types/schema.ts`
+- `src/core/combinators/typed-struct.ts`
+- `src/core/combinators/struct.ts`
+- `tests/core/combinators/typed-struct.test.ts`
+- `tests-d/core/combinators/typed-struct.test-d.ts`
+- `docs/app/api-reference/combinators/typed-struct/page.tsx`
+- `docs/app/guides/keep-type-guards-in-sync/page.tsx`

--- a/README.md
+++ b/README.md
@@ -600,6 +600,7 @@ public root exports are planned for removal.
 For detailed API pages and more examples, see:
 
 - [Practical guides](https://is-kit-docs.vercel.app/guides)
+- [Keep hand-written type guards in sync with TypeScript types](https://is-kit-docs.vercel.app/guides/keep-type-guards-in-sync)
 - [API reference](https://is-kit-docs.vercel.app/api-reference)
 - [Documentation home](https://is-kit-docs.vercel.app/)
 

--- a/README.md
+++ b/README.md
@@ -521,7 +521,9 @@ if (parsed.valid) {
 sync with an existing object type. Optional keys in `T` must still be declared
 with `optionalKey(...)`; this makes drift visible when the target type changes.
 OpenAPI-generated response types are one useful case, but the helper is not an
-OpenAPI validator or schema generator.
+OpenAPI validator or schema generator. Drift detection is limited to
+string-keyed properties; numeric and symbol properties are excluded from the
+checked shape and cannot be validated by the resulting guard.
 
 ### Safe array filtering
 

--- a/docs/app/api-reference/combinators/typed-struct/page.tsx
+++ b/docs/app/api-reference/combinators/typed-struct/page.tsx
@@ -67,6 +67,11 @@ export default function TypedStructPage() {
             target type changes. This helper is not an OpenAPI validator or a
             schema generator.
           </Paragraph>
+          <Paragraph>
+            Drift detection is limited to string-keyed properties. Numeric and
+            symbol properties are excluded from <code>TypedStructShape</code>{' '}
+            and cannot be declared or validated by the resulting guard.
+          </Paragraph>
         </Stack>
         <CodeBlock code={sample} language='ts' />
       </Stack>

--- a/docs/app/guides/keep-type-guards-in-sync/page.tsx
+++ b/docs/app/guides/keep-type-guards-in-sync/page.tsx
@@ -1,0 +1,409 @@
+import { CodeBlock } from '@/components/code/code-block';
+import { Heading } from '@/components/ui/heading';
+import { Paragraph } from '@/components/ui/paragraph';
+import { Stack } from '@/components/ui/stack';
+import { TextLink } from '@/components/ui/text-link';
+import { GUIDE_PATHS } from '@/constants/guides';
+import { API_REFERENCE_PATHS } from '@/lib/api-metadata';
+import { createGuideMetadata } from '@/lib/guide-metadata';
+
+export const metadata = createGuideMetadata(GUIDE_PATHS.syncTypeGuards);
+
+const quickAnswer = `import {
+  isNumber,
+  isString,
+  optionalKey,
+  typedStruct,
+} from 'is-kit';
+
+type User = {
+  id: string;
+  name: string;
+  age?: number;
+};
+
+const isUser = typedStruct<User>()({
+  id: isString,
+  name: isString,
+  age: optionalKey(isNumber),
+});
+
+declare const input: unknown;
+
+if (isUser(input)) {
+  input.name.toUpperCase();
+  // input: Readonly<User>
+}`;
+
+const trustedAnnotation = `type User = {
+  id: string;
+  name: string;
+  role: 'admin' | 'member';
+};
+
+const isUser = (value: unknown): value is User => {
+  if (typeof value !== 'object' || value === null) return false;
+
+  const candidate = value as Record<string, unknown>;
+  return (
+    typeof candidate.id === 'string' &&
+    typeof candidate.name === 'string'
+  );
+};
+
+// The implementation forgot role, but the annotation still compiles.
+// TypeScript trusts a user-defined type predicate.`;
+
+const visibleDrift = `import {
+  isNumber,
+  isString,
+  oneOfValues,
+  optionalKey,
+  typedStruct,
+} from 'is-kit';
+
+type User = {
+  id: string;
+  name: string;
+  role: 'admin' | 'member';
+  age?: number;
+};
+
+typedStruct<User>()({
+  id: isString,
+  name: isString,
+  age: optionalKey(isNumber),
+  // TypeScript error: role is missing.
+});
+
+typedStruct<User>()({
+  id: isString,
+  name: isNumber,
+  // TypeScript error: name requires a string-compatible guard.
+  role: oneOfValues('admin', 'member'),
+  age: optionalKey(isNumber),
+});`;
+
+const optionalFields = `import {
+  isString,
+  nullable,
+  optionalKey,
+  typedStruct,
+} from 'is-kit';
+
+type User = {
+  id: string;
+  nickname?: string | null;
+};
+
+const isUser = typedStruct<User>()({
+  id: isString,
+  nickname: optionalKey(nullable(isString)),
+});
+
+isUser({ id: 'user-1' }); // true
+isUser({ id: 'user-1', nickname: null }); // true
+isUser({ id: 'user-1', nickname: 'Neko' }); // true
+isUser({ id: 'user-1', nickname: 42 }); // false`;
+
+const nestedTypes = `import {
+  arrayOf,
+  isString,
+  nullable,
+  typedStruct,
+} from 'is-kit';
+
+type Account = {
+  readonly id: string;
+  readonly profile: {
+    readonly displayName: string;
+    readonly bio: string | null;
+  } | null;
+  readonly tags: readonly string[];
+};
+
+const isProfile = typedStruct<NonNullable<Account['profile']>>()({
+  displayName: isString,
+  bio: nullable(isString),
+});
+
+const isAccount = typedStruct<Account>()({
+  id: isString,
+  profile: nullable(isProfile),
+  tags: arrayOf(isString),
+});`;
+
+const exactObjects = `import { isString, typedStruct } from 'is-kit';
+
+type User = {
+  id: string;
+  name: string;
+};
+
+const isExactUser = typedStruct<User>()(
+  {
+    id: isString,
+    name: isString,
+  },
+  { exact: true },
+);
+
+isExactUser({ id: 'user-1', name: 'Ada' }); // true
+isExactUser({ id: 'user-1', name: 'Ada', debug: true }); // false`;
+
+export default function KeepTypeGuardsInSyncGuidePage() {
+  return (
+    <Stack
+      variant='article'
+      className='container mx-auto max-w-4xl px-4 py-10'
+      gap='xl'
+    >
+      <Stack variant='section' gap='sm' className='border-b pb-8'>
+        <nav aria-label='Breadcrumb'>
+          <ol className='flex items-center gap-2 text-sm font-medium tracking-[0.14em] uppercase text-primary/70'>
+            <li>
+              <TextLink href={GUIDE_PATHS.index} className='text-inherit'>
+                Guides
+              </TextLink>
+            </li>
+            <li aria-hidden='true'>/</li>
+            <li aria-current='page'>Sync type guards</li>
+          </ol>
+        </nav>
+        <Heading
+          variant='h1'
+          className='max-w-3xl leading-tight tracking-tight'
+        >
+          How to Keep Hand-Written Type Guards in Sync with TypeScript Types
+        </Heading>
+        <Paragraph variant='lead' className='max-w-3xl text-primary/80'>
+          Start with the type you already have, write the runtime checks by
+          hand, and make structural drift a compile-time error.
+        </Paragraph>
+      </Stack>
+
+      <Stack variant='section' gap='md'>
+        <Heading variant='h2' className='text-2xl tracking-tight'>
+          The quick answer
+        </Heading>
+        <Paragraph>
+          Pass your existing object type to <code>typedStruct</code>, then
+          define one guard for every field.
+        </Paragraph>
+        <CodeBlock code={quickAnswer} language='ts' />
+        <Paragraph>
+          At runtime, this uses the same object validation as{' '}
+          <code>struct</code>. At compile time, the field map is checked against{' '}
+          <code>User</code> for missing, extra, and incompatible fields.
+        </Paragraph>
+        <Paragraph>
+          The guards are still explicit. The useful part is that the compiler
+          now knows which type they are supposed to follow.
+        </Paragraph>
+      </Stack>
+
+      <Stack variant='section' gap='md'>
+        <Heading variant='h2' className='text-2xl tracking-tight'>
+          Why a type predicate can drift silently
+        </Heading>
+        <Paragraph>
+          A hand-written predicate often starts small. Then the application type
+          gains a field, while the runtime check stays unchanged.
+        </Paragraph>
+        <CodeBlock code={trustedAnnotation} language='ts' />
+        <Paragraph>
+          This is valid TypeScript. A return type such as{' '}
+          <code>value is User</code> is a promise made by your function, not a
+          proof derived from its body.
+        </Paragraph>
+        <blockquote className='border-l-2 border-primary/70 py-1 pl-5 text-lg leading-relaxed'>
+          The compiler can check a guard’s declared type. It cannot prove that
+          arbitrary runtime logic checks every field.
+        </blockquote>
+      </Stack>
+
+      <Stack variant='section' gap='md'>
+        <Heading variant='h2' className='text-2xl tracking-tight'>
+          Make structural drift visible
+        </Heading>
+        <Paragraph>
+          <code>typedStruct&lt;User&gt;()</code> turns the object type into a
+          compile-time contract for the field map.
+        </Paragraph>
+        <CodeBlock code={visibleDrift} language='ts' />
+        <Paragraph>
+          The same check also rejects schema fields that do not exist on{' '}
+          <code>User</code>. Renames, additions, removals, and field-type
+          changes therefore surface next to the guard definition during type
+          checking.
+        </Paragraph>
+        <Paragraph>
+          This does not remove maintenance. It moves forgotten maintenance from
+          production behavior into a compiler error.
+        </Paragraph>
+      </Stack>
+
+      <Stack variant='section' gap='md'>
+        <Heading variant='h2' className='text-2xl tracking-tight'>
+          Keep optional keys explicit
+        </Heading>
+        <Paragraph>
+          Optional object properties must still appear in the field map. Wrap
+          them with <code>optionalKey</code> so the key may be absent at
+          runtime.
+        </Paragraph>
+        <CodeBlock code={optionalFields} language='ts' />
+        <Paragraph>
+          Key optionality and value nullability are separate decisions. Here,
+          <code>optionalKey</code> allows <code>nickname</code> to be absent,
+          while <code>nullable</code> allows an existing key to contain{' '}
+          <code>null</code>.
+        </Paragraph>
+        <Paragraph>
+          Requiring optional keys in the field map is deliberate. If a new
+          optional property is added to <code>User</code>, the guard should not
+          ignore it silently.
+        </Paragraph>
+      </Stack>
+
+      <Stack variant='section' gap='md'>
+        <Heading variant='h2' className='text-2xl tracking-tight'>
+          Compose nested existing types
+        </Heading>
+        <Paragraph>
+          For nested objects, define a focused guard from the corresponding
+          property type and compose it into the parent guard.
+        </Paragraph>
+        <CodeBlock code={nestedTypes} language='ts' />
+        <Paragraph>
+          Referencing <code>Account['profile']</code> keeps the nested guard
+          connected to the original type without copying the object shape into
+          another TypeScript alias.
+        </Paragraph>
+        <blockquote className='border-l-2 border-primary/70 py-1 pl-5 text-lg leading-relaxed font-semibold'>
+          Reuse the existing type at compile time. Compose small guards at
+          runtime.
+        </blockquote>
+      </Stack>
+
+      <Stack variant='section' gap='md'>
+        <Heading variant='h2' className='text-2xl tracking-tight'>
+          Compile-time fields and runtime extra keys
+        </Heading>
+        <Paragraph>
+          <code>typedStruct</code> always rejects extra fields in the guard
+          definition. Extra keys in an input object are a separate runtime
+          choice.
+        </Paragraph>
+        <CodeBlock code={exactObjects} language='ts' />
+        <Paragraph>
+          Without <code>{'{ exact: true }'}</code>, matching objects may contain
+          additional own enumerable string keys. Enable it when the runtime
+          boundary requires a closed object shape.
+        </Paragraph>
+      </Stack>
+
+      <Stack variant='section' gap='md'>
+        <Heading variant='h2' className='text-2xl tracking-tight'>
+          Choose the right source of truth
+        </Heading>
+        <div className='overflow-x-auto rounded-md border'>
+          <table className='w-full min-w-2xl border-collapse text-left text-sm'>
+            <thead>
+              <tr className='border-b bg-primary/5'>
+                <th className='px-4 py-3 font-semibold tracking-wide'>
+                  Approach
+                </th>
+                <th className='px-4 py-3 font-semibold tracking-wide'>
+                  Source of truth
+                </th>
+                <th className='px-4 py-3 font-semibold tracking-wide'>
+                  Best for
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr className='border-b'>
+                <td className='px-4 py-3'>Manual predicate</td>
+                <td className='px-4 py-3'>Your implementation</td>
+                <td className='px-4 py-3'>Custom, non-structural logic</td>
+              </tr>
+              <tr className='border-b'>
+                <td className='px-4 py-3'>struct</td>
+                <td className='px-4 py-3'>The guard field map</td>
+                <td className='px-4 py-3'>Guard-first object types</td>
+              </tr>
+              <tr className='border-b'>
+                <td className='px-4 py-3'>typedStruct</td>
+                <td className='px-4 py-3'>An existing TypeScript type</td>
+                <td className='px-4 py-3'>Type-first application code</td>
+              </tr>
+              <tr>
+                <td className='px-4 py-3'>Schema library or codegen</td>
+                <td className='px-4 py-3'>A schema or generated artifact</td>
+                <td className='px-4 py-3'>
+                  Rich errors, transforms, or generation
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <Paragraph>
+          Use <code>struct</code> when the guard should define the resulting
+          type. Use <code>typedStruct</code> when the TypeScript type already
+          exists and the hand-written guard must follow it.
+        </Paragraph>
+      </Stack>
+
+      <Stack variant='section' gap='md'>
+        <Heading variant='h2' className='text-2xl tracking-tight'>
+          What typedStruct does not do
+        </Heading>
+        <ul className='list-disc space-y-2 pl-6'>
+          <li>It does not generate runtime validation from erased types.</li>
+          <li>
+            It cannot prove that a custom predicate’s implementation is honest.
+          </li>
+          <li>
+            It does not coerce data or return structured validation errors.
+          </li>
+          <li>
+            It does not replace a schema-first workflow when a schema is your
+            actual source of truth.
+          </li>
+        </ul>
+        <Paragraph>
+          It is intentionally smaller: a typed bridge between an existing object
+          type and the guards you choose to run.
+        </Paragraph>
+      </Stack>
+
+      <Stack variant='section' gap='md' className='border-t pt-8'>
+        <Heading variant='h2' className='text-2xl tracking-tight'>
+          Summary
+        </Heading>
+        <ul className='list-disc space-y-2 pl-6'>
+          <li>
+            Use <code>typedStruct&lt;T&gt;()</code> when <code>T</code> already
+            exists and needs a runtime guard.
+          </li>
+          <li>
+            Declare required and optional keys so type drift stays visible.
+          </li>
+          <li>Compose nested guards from the corresponding property types.</li>
+          <li>
+            Use <code>exact: true</code> only when runtime inputs must reject
+            additional keys.
+          </li>
+        </ul>
+        <Paragraph>
+          For the complete contract and additional examples, see the{' '}
+          <TextLink href={API_REFERENCE_PATHS.typedStruct}>
+            typedStruct API reference
+          </TextLink>
+          .
+        </Paragraph>
+      </Stack>
+    </Stack>
+  );
+}

--- a/docs/app/guides/keep-type-guards-in-sync/page.tsx
+++ b/docs/app/guides/keep-type-guards-in-sync/page.tsx
@@ -188,13 +188,14 @@ export default function KeepTypeGuardsInSyncGuidePage() {
         </Heading>
         <Paragraph>
           Pass your existing object type to <code>typedStruct</code>, then
-          define one guard for every field.
+          define one guard for every string-keyed field.
         </Paragraph>
         <CodeBlock code={quickAnswer} language='ts' />
         <Paragraph>
           At runtime, this uses the same object validation as{' '}
           <code>struct</code>. At compile time, the field map is checked against{' '}
-          <code>User</code> for missing, extra, and incompatible fields.
+          <code>User</code> for missing, extra, and incompatible string-keyed
+          fields.
         </Paragraph>
         <Paragraph>
           The guards are still explicit. The useful part is that the compiler
@@ -224,23 +225,30 @@ export default function KeepTypeGuardsInSyncGuidePage() {
 
       <Stack variant='section' gap='md'>
         <Heading variant='h2' className='text-2xl tracking-tight'>
-          Make structural drift visible
+          Make string-keyed structural drift visible
         </Heading>
         <Paragraph>
+          For ordinary string-keyed object shapes,{' '}
           <code>typedStruct&lt;User&gt;()</code> turns the object type into a
           compile-time contract for the field map.
         </Paragraph>
         <CodeBlock code={visibleDrift} language='ts' />
         <Paragraph>
-          The same check also rejects schema fields that do not exist on{' '}
-          <code>User</code>. Renames, additions, removals, and field-type
-          changes therefore surface next to the guard definition during type
-          checking.
+          The same check also rejects string-keyed schema fields that do not
+          exist on <code>User</code>. String-keyed renames, additions, removals,
+          and field-type changes therefore surface next to the guard definition
+          during type checking.
         </Paragraph>
         <Paragraph>
           This does not remove maintenance. It moves forgotten maintenance from
           production behavior into a compiler error.
         </Paragraph>
+        <blockquote className='border-l-2 border-primary/70 py-1 pl-5 text-lg leading-relaxed'>
+          This drift guarantee is limited to string-keyed properties. Numeric
+          and symbol properties are excluded from <code>TypedStructShape</code>,
+          so they are not required in the field map and cannot be validated by
+          the resulting <code>typedStruct</code> guard.
+        </blockquote>
       </Stack>
 
       <Stack variant='section' gap='md'>
@@ -248,9 +256,9 @@ export default function KeepTypeGuardsInSyncGuidePage() {
           Keep optional keys explicit
         </Heading>
         <Paragraph>
-          Optional object properties must still appear in the field map. Wrap
-          them with <code>optionalKey</code> so the key may be absent at
-          runtime.
+          Optional string-keyed object properties must still appear in the field
+          map. Wrap them with <code>optionalKey</code> so the key may be absent
+          at runtime.
         </Paragraph>
         <CodeBlock code={optionalFields} language='ts' />
         <Paragraph>
@@ -261,8 +269,8 @@ export default function KeepTypeGuardsInSyncGuidePage() {
         </Paragraph>
         <Paragraph>
           Requiring optional keys in the field map is deliberate. If a new
-          optional property is added to <code>User</code>, the guard should not
-          ignore it silently.
+          optional string-keyed property is added to <code>User</code>, the
+          guard should not ignore it silently.
         </Paragraph>
       </Stack>
 
@@ -291,8 +299,8 @@ export default function KeepTypeGuardsInSyncGuidePage() {
           Compile-time fields and runtime extra keys
         </Heading>
         <Paragraph>
-          <code>typedStruct</code> always rejects extra fields in the guard
-          definition. Extra keys in an input object are a separate runtime
+          <code>typedStruct</code> rejects extra string-keyed fields in the
+          guard definition. Extra keys in an input object are a separate runtime
           choice.
         </Paragraph>
         <CodeBlock code={exactObjects} language='ts' />
@@ -362,6 +370,10 @@ export default function KeepTypeGuardsInSyncGuidePage() {
         <ul className='list-disc space-y-2 pl-6'>
           <li>It does not generate runtime validation from erased types.</li>
           <li>
+            It does not track or validate numeric and symbol properties on the
+            target type.
+          </li>
+          <li>
             It cannot prove that a custom predicate’s implementation is honest.
           </li>
           <li>
@@ -384,11 +396,12 @@ export default function KeepTypeGuardsInSyncGuidePage() {
         </Heading>
         <ul className='list-disc space-y-2 pl-6'>
           <li>
-            Use <code>typedStruct&lt;T&gt;()</code> when <code>T</code> already
-            exists and needs a runtime guard.
+            Use <code>typedStruct&lt;T&gt;()</code> when a string-keyed object
+            type <code>T</code> already exists and needs a runtime guard.
           </li>
           <li>
-            Declare required and optional keys so type drift stays visible.
+            Declare required and optional string keys so type drift stays
+            visible.
           </li>
           <li>Compose nested guards from the corresponding property types.</li>
           <li>

--- a/docs/constants/guides.ts
+++ b/docs/constants/guides.ts
@@ -2,7 +2,8 @@ import type { SidebarSection } from '@/components/navigation/sidebar';
 
 export const GUIDE_PATHS = {
   index: '/guides',
-  filterNullish: '/guides/filter-null-and-undefined'
+  filterNullish: '/guides/filter-null-and-undefined',
+  syncTypeGuards: '/guides/keep-type-guards-in-sync'
 } as const;
 
 export type GuidePath = (typeof GUIDE_PATHS)[keyof typeof GUIDE_PATHS];
@@ -21,6 +22,13 @@ export const GUIDE_ITEMS: GuideItem[] = [
     navigationLabel: 'Filter nullish values',
     description:
       'Remove nullish array entries without losing TypeScript narrowing or valid falsy values.'
+  },
+  {
+    href: GUIDE_PATHS.syncTypeGuards,
+    title: 'Keep hand-written type guards in sync with TypeScript types',
+    navigationLabel: 'Sync type guards',
+    description:
+      'Make missing, extra, and incompatible guard fields visible when an existing object type changes.'
   }
 ];
 

--- a/docs/constants/guides.ts
+++ b/docs/constants/guides.ts
@@ -28,7 +28,7 @@ export const GUIDE_ITEMS: GuideItem[] = [
     title: 'Keep hand-written type guards in sync with TypeScript types',
     navigationLabel: 'Sync type guards',
     description:
-      'Make missing, extra, and incompatible guard fields visible when an existing object type changes.'
+      'Make missing, extra, and incompatible string-keyed guard fields visible when an existing object type changes.'
   }
 ];
 

--- a/docs/lib/api-metadata.ts
+++ b/docs/lib/api-metadata.ts
@@ -133,7 +133,7 @@ const API_METADATA = {
   [API_REFERENCE_PATHS.typedStruct]: {
     title: 'typedStruct — Guard Existing TypeScript Types | is-kit',
     description:
-      'Keep a hand-written runtime object guard aligned with an existing TypeScript type using typedStruct and field-level checks.'
+      'Keep a hand-written runtime object guard aligned with an existing string-keyed TypeScript type using typedStruct and field-level checks.'
   },
   [API_REFERENCE_PATHS.oneOfValues]: {
     title: 'oneOfValues — TypeScript Literal Value Guard | is-kit',

--- a/docs/lib/guide-metadata.ts
+++ b/docs/lib/guide-metadata.ts
@@ -17,6 +17,11 @@ const GUIDE_METADATA = {
     title: 'Filter null and undefined from Arrays in TypeScript | is-kit',
     description:
       'Safely filter null and undefined from TypeScript arrays while preserving type narrowing and valid falsy values.'
+  },
+  [GUIDE_PATHS.syncTypeGuards]: {
+    title: 'Keep Type Guards in Sync with TypeScript Types | is-kit',
+    description:
+      'Keep hand-written runtime guards aligned with existing TypeScript object types using typedStruct and field-level checks.'
   }
 } as const satisfies Record<GuidePath, GuideMetadataCopy>;
 

--- a/docs/lib/guide-metadata.ts
+++ b/docs/lib/guide-metadata.ts
@@ -21,7 +21,7 @@ const GUIDE_METADATA = {
   [GUIDE_PATHS.syncTypeGuards]: {
     title: 'Keep Type Guards in Sync with TypeScript Types | is-kit',
     description:
-      'Keep hand-written runtime guards aligned with existing TypeScript object types using typedStruct and field-level checks.'
+      'Keep hand-written runtime guards aligned with existing string-keyed TypeScript object types using typedStruct and field-level checks.'
   }
 } as const satisfies Record<GuidePath, GuideMetadataCopy>;
 

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -55,6 +55,7 @@ const presentNames = names.filter(isNotNil); // string[]
 - [Documentation](https://is-kit-docs.vercel.app/en)
 - [Practical guides](https://is-kit-docs.vercel.app/guides)
 - [Filter null and undefined from arrays in TypeScript](https://is-kit-docs.vercel.app/guides/filter-null-and-undefined)
+- [Keep hand-written type guards in sync with TypeScript types](https://is-kit-docs.vercel.app/guides/keep-type-guards-in-sync)
 - [API reference](https://is-kit-docs.vercel.app/api-reference)
 - [README and usage guide](https://github.com/nyaomaru/is-kit#readme)
 - [AI agent rules](https://github.com/nyaomaru/is-kit/blob/main/docs/agent-rules.md)

--- a/src/core/combinators/typed-struct.ts
+++ b/src/core/combinators/typed-struct.ts
@@ -8,7 +8,9 @@ import type {
 import { struct } from './struct';
 
 /**
- * Creates a `struct` builder checked against an existing object type.
+ * Creates a `struct` builder checked against an existing string-keyed object
+ * type. Numeric and symbol properties are excluded from the checked shape and
+ * cannot be validated by the resulting guard.
  * Optional target keys must also be declared with `optionalKey` so type drift
  * stays visible when the target type changes.
  *

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -81,7 +81,8 @@ export type OptionalObjectKeys<T> = {
 export type RequiredObjectKeys<T> = Exclude<keyof T, OptionalObjectKeys<T>>;
 
 /**
- * Schema shape checked against an existing object type by `typedStruct`.
+ * String-keyed schema shape checked against an existing object type by
+ * `typedStruct`. Numeric and symbol properties are excluded.
  */
 export type TypedStructShape<T extends object> = {
   readonly [K in Extract<RequiredObjectKeys<T>, string>]-?: Predicate<T[K]>;


### PR DESCRIPTION
## Summary

Add guide for keeping type guards in sync.

<!-- A brief summary of the changes -->

## Description

- add a practical guide for keeping hand-written runtime guards aligned with existing TypeScript types
- explain how `typedStruct<T>()` detects missing, extra, and incompatible guard fields
- cover optional keys, nullable values, nested types, and exact object validation

<!-- A detailed explanation of the changes, including why they are needed -->
