### PR TITLE
docs: migrate documentation URLs to is-kit.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ It helps you write small `isFoo` functions, compose them into **richer runtime c
 - **Validate object** shapes and collections
 - **Parse or assert** `unknown` values without a large schema framework
 
-[📚 Documentation Site](https://is-kit-docs.vercel.app/) ·
-[🧭 Practical Guides](https://is-kit-docs.vercel.app/guides)
+[📚 Documentation Site](https://is-kit.dev/) ·
+[🧭 Practical Guides](https://is-kit.dev/guides)
 
 > Best for **app-internal narrowing, filtering, and reusable guards**.
 
@@ -601,14 +601,14 @@ public root exports are planned for removal.
 
 For detailed API pages and more examples, see:
 
-- [Practical guides](https://is-kit-docs.vercel.app/guides)
-- [Keep hand-written type guards in sync with TypeScript types](https://is-kit-docs.vercel.app/guides/keep-type-guards-in-sync)
-- [Validate unknown without a schema library](https://is-kit-docs.vercel.app/guides/validate-unknown-without-schema-library)
-- [API reference](https://is-kit-docs.vercel.app/api-reference)
-- [Documentation home](https://is-kit-docs.vercel.app/)
+- [Practical guides](https://is-kit.dev/guides)
+- [Keep hand-written type guards in sync with TypeScript types](https://is-kit.dev/guides/keep-type-guards-in-sync)
+- [Validate unknown without a schema library](https://is-kit.dev/guides/validate-unknown-without-schema-library)
+- [API reference](https://is-kit.dev/api-reference)
+- [Documentation home](https://is-kit.dev/)
 
 Start with [How to safely filter null and undefined from arrays in
-TypeScript](https://is-kit-docs.vercel.app/guides/filter-null-and-undefined).
+TypeScript](https://is-kit.dev/guides/filter-null-and-undefined).
 
 ## 👨‍💻 Development
 

--- a/docs/constants/site.ts
+++ b/docs/constants/site.ts
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 
-export const SITE_URL = 'https://is-kit-docs.vercel.app';
+export const SITE_URL = 'https://is-kit.dev';
 
 export const SITE_TITLE = 'is-kit Docs — TypeScript Type Guard Toolkit';
 

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -52,12 +52,12 @@ const presentNames = names.filter(isNotNil); // string[]
 
 ## Documentation
 
-- [Documentation](https://is-kit-docs.vercel.app/en)
-- [Practical guides](https://is-kit-docs.vercel.app/guides)
-- [Filter null and undefined from arrays in TypeScript](https://is-kit-docs.vercel.app/guides/filter-null-and-undefined)
-- [Keep hand-written type guards in sync with TypeScript types](https://is-kit-docs.vercel.app/guides/keep-type-guards-in-sync)
-- [Validate unknown without a schema library](https://is-kit-docs.vercel.app/guides/validate-unknown-without-schema-library)
-- [API reference](https://is-kit-docs.vercel.app/api-reference)
+- [Documentation](https://is-kit.dev/en)
+- [Practical guides](https://is-kit.dev/guides)
+- [Filter null and undefined from arrays in TypeScript](https://is-kit.dev/guides/filter-null-and-undefined)
+- [Keep hand-written type guards in sync with TypeScript types](https://is-kit.dev/guides/keep-type-guards-in-sync)
+- [Validate unknown without a schema library](https://is-kit.dev/guides/validate-unknown-without-schema-library)
+- [API reference](https://is-kit.dev/api-reference)
 - [README and usage guide](https://github.com/nyaomaru/is-kit#readme)
 - [AI agent rules](https://github.com/nyaomaru/is-kit/blob/main/docs/agent-rules.md)
 - [npm package](https://www.npmjs.com/package/is-kit)

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   "bugs": {
     "url": "https://github.com/nyaomaru/is-kit/issues"
   },
-  "homepage": "https://is-kit-docs.vercel.app/",
+  "homepage": "https://is-kit.dev/",
   "author": "nyaomaru",
   "license": "MIT",
   "packageManager": "pnpm@11.2.2",

--- a/plugins/is-kit/.codex-plugin/plugin.json
+++ b/plugins/is-kit/.codex-plugin/plugin.json
@@ -6,7 +6,7 @@
     "name": "nyaomaru",
     "url": "https://github.com/nyaomaru"
   },
-  "homepage": "https://is-kit-docs.vercel.app/",
+  "homepage": "https://is-kit.dev/",
   "repository": "https://github.com/nyaomaru/is-kit",
   "license": "MIT",
   "keywords": [
@@ -23,7 +23,7 @@
     "developerName": "nyaomaru",
     "category": "Developer Tools",
     "capabilities": ["Read", "Write"],
-    "websiteURL": "https://is-kit-docs.vercel.app/",
+    "websiteURL": "https://is-kit.dev/",
     "defaultPrompt": [
       "Replace manual TypeScript checks with composable is-kit guards.",
       "Validate an unknown API response with is-kit."


### PR DESCRIPTION
## Summary

Migrate documentation URLs to `is-kit.dev`.

<!-- A brief summary of the changes -->

## Description

- migrate the canonical documentation domain from `is-kit-docs.vercel.app` to `is-kit.dev`
- update canonical URLs, Open Graph metadata, sitemap entries, and `robots.txt`
- update documentation links in the README and `llms.txt`

<!-- A detailed explanation of the changes, including why they are needed -->
