### PR TITLE
chore(docs): use PNG image for social previews

### DIFF
--- a/docs/constants/site.ts
+++ b/docs/constants/site.ts
@@ -7,7 +7,7 @@ export const SITE_TITLE = 'is-kit Docs — TypeScript Type Guard Toolkit';
 export const SITE_DESCRIPTION =
   'Documentation for is-kit, a lightweight, zero-dependency toolkit for building composable TypeScript type guards.';
 
-export const SITE_SOCIAL_IMAGE = '/iskit_logo1.svg';
+export const SITE_SOCIAL_IMAGE = '/iskit-logo_700_500.png';
 
 export const SITE_OPEN_GRAPH = {
   type: 'website',
@@ -15,6 +15,9 @@ export const SITE_OPEN_GRAPH = {
   images: [
     {
       url: SITE_SOCIAL_IMAGE,
+      width: 2917,
+      height: 2084,
+      type: 'image/png',
       alt: 'is-kit logo'
     }
   ]


### PR DESCRIPTION
## Summary

Use PNG image for social previews.

<!-- A brief summary of the changes -->

## Description

- replace the SVG social preview image with a PNG

<!-- A detailed explanation of the changes, including why they are needed -->
