### PR TITLE
feat: support known-domain refinement composition

### DIFF
--- a/.codex/skills/learn/LEARNED_INDEX.md
+++ b/.codex/skills/learn/LEARNED_INDEX.md
@@ -3,4 +3,6 @@
 - **[deprecate-public-api-before-major-removal](learned/deprecate-public-api-before-major-removal.md)** - Deprecate accidental runtime exports during the current major before removing only their public entry point in the next major.
 - **[keep-typed-schema-key-coverage-explicit](learned/keep-typed-schema-key-coverage-explicit.md)** - Match typed schema drift claims to the string-key coverage enforced by both mapped types and runtime enumeration.
 - **[model-transformations-as-decoders](learned/model-transformations-as-decoders.md)** - Model value-changing boundary conversions as ParseResult-returning decoder functions rather than type guards.
+- **[order-precise-overloads-before-generic-fallbacks](learned/order-precise-overloads-before-generic-fallbacks.md)** - Put tuple-preserving overloads before homogeneous array fallbacks so concrete chains retain their final narrowing.
+- **[preserve-explicit-generic-call-compatibility](learned/preserve-explicit-generic-call-compatibility.md)** - Treat public type-parameter shape as source API and test explicit generic calls when generalizing signatures.
 - **[test-packed-artifacts-from-a-consumer-project](learned/test-packed-artifacts-from-a-consumer-project.md)** - Install the packed tarball in a temporary consumer to verify ESM, CommonJS, and declaration resolution before publishing.

--- a/.codex/skills/learn/learned/order-precise-overloads-before-generic-fallbacks.md
+++ b/.codex/skills/learn/learned/order-precise-overloads-before-generic-fallbacks.md
@@ -1,0 +1,84 @@
+# Order Precise Overloads Before Generic Fallbacks
+
+**Captured:** 2026-08-20
+**Context:** Variadic refinement APIs that support both concrete narrowing tuples and generic homogeneous arrays
+**Tags:** typescript, type-guards, refinements, overloads, tuples, arrays, inference, tsd
+
+## Problem
+
+TypeScript selects the first applicable overload, even when a later overload
+would preserve more type information. A broad homogeneous-array overload such
+as `readonly Refine<B, B>[]` can accept a concrete tuple whose refinements all
+accept `B` but progressively narrow to subtypes of `B`.
+
+If that array overload appears before a recursive tuple overload, TypeScript
+returns its conservative `Refinement<A, B>` result and discards the tuple's
+final narrowed type. Removing the array overload is not sufficient because
+recursive conditional types such as `RefineChain<B, Steps>` remain unresolved
+for generic rest tuples and ordinary arrays, causing `TS2769`.
+
+## Solution
+
+Order overloads from the most type-preserving shape to the broadest fallback:
+
+1. Fixed-arity overloads for common calls.
+2. A recursive tuple overload that computes the final narrowed type.
+3. A homogeneous-array overload that accepts unresolved generic arrays and
+   conservatively retains the initial narrowed type.
+
+Use `NoInfer` in the fallback's step domain so the array cannot widen the type
+inferred from the precondition. Keep the runtime implementation unchanged;
+this is an overload-resolution concern.
+
+## Example
+
+```ts
+export function andAll<A, B extends A, Chain extends readonly unknown[]>(
+  precondition: Refinement<A, B>,
+  ...steps: Chain & RefineChain<NoInfer<B>, Chain>
+): Refinement<A, ChainResult<B, Chain>>;
+
+// Keep this after the recursive tuple overload.
+export function andAll<A, B extends A>(
+  precondition: Refinement<A, B>,
+  ...steps: readonly Refine<NoInfer<B>, NoInfer<B>>[]
+): Refinement<A, B>;
+```
+
+Test both sides of the overload boundary:
+
+```ts
+// A concrete tuple must preserve its final refinement.
+expectType<Refine<Input, Final>>(andAll(precondition, ...concreteSteps));
+
+// An unresolved generic array must remain accepted.
+function compose<
+  A,
+  B extends A,
+  Steps extends readonly Refine<B, B>[]
+>(precondition: Refine<A, B>, steps: Steps) {
+  expectType<Refine<A, B>>(andAll(precondition, ...steps));
+}
+```
+
+## When To Use
+
+Use this pattern when an overloaded variadic API must support both concrete
+tuples with position-dependent inference and generic or ordinary arrays whose
+length and element sequence are unresolved.
+
+Verify both successful call categories and inspect TypeScript diagnostics:
+
+```text
+pnpm lint
+pnpm build
+pnpm exec tsc -p tests-d/tsconfig.json
+pnpm test
+pnpm test:types
+```
+
+## Related Files
+
+- `src/core/logic.ts`
+- `src/types/core.ts`
+- `tests-d/core/logic.test-d.ts`

--- a/.codex/skills/learn/learned/preserve-explicit-generic-call-compatibility.md
+++ b/.codex/skills/learn/learned/preserve-explicit-generic-call-compatibility.md
@@ -1,0 +1,74 @@
+# Preserve Explicit Generic Call Compatibility
+
+**Captured:** 2026-08-19
+**Context:** Generalizing public combinators from unknown-input guards to known-domain refinements
+**Tags:** typescript, type-guards, refinements, api-design, backward-compatibility, tsd
+
+## Problem
+
+A generalized signature can preserve inference for ordinary calls while still
+breaking consumers that explicitly supply generic arguments. TypeScript treats
+the number, order, and constraints of public type parameters as observable API.
+Runtime parity and unchanged inferred hover types therefore do not prove source
+compatibility.
+
+For example, changing `and` from `<A, B extends A>` to
+`<Precondition extends BooleanRefinement, B extends GuardedOf<Precondition>>`
+keeps `and(isString, isLiteralA)` working, but changes the meaning of the first
+explicit type argument. A previously valid call such as
+`and<string, 'a'>(isString, isLiteralA)` no longer compiles because `string`
+does not satisfy the new function constraint.
+
+## Solution
+
+Audit both inferred and explicit-generic calls whenever a public generic
+signature is replaced. Add `tsd` fixtures that exercise representative explicit
+type arguments for every changed overload.
+
+If the feature must ship in a minor release, retain compatibility overloads for
+the old generic parameter shape and add the generalized refinement overloads
+alongside them. Verify that overload order preserves existing inference. If the
+legacy overloads cannot coexist without ambiguity or degraded inference, treat
+the signature change as semver-major even when runtime behavior is unchanged.
+
+## Example
+
+```ts
+const isLiteralA = (value: string): value is 'a' => value === 'a';
+
+// Inferred use can remain compatible after a signature rewrite.
+const inferred = and(isString, isLiteralA);
+
+// This is also public source surface and needs a compatibility test.
+const explicit = and<string, 'a'>(isString, isLiteralA);
+```
+
+Apply the same audit to variadic combinators such as `andAll`, `or`, and
+`oneOf`, whose tuple or leading-function generic parameters can also change
+meaning across signature rewrites.
+
+## When To Use
+
+Use this pattern when changing public overloads, generic parameter order,
+generic constraints, or conditional return types, especially when broadening a
+guard API to accept known-domain refinements.
+
+Run at least:
+
+```text
+pnpm lint
+pnpm build
+pnpm test
+pnpm test:types
+pnpm test:package
+```
+
+## Related Files
+
+- `src/core/logic.ts`
+- `src/core/combinators/one-of.ts`
+- `src/types/core.ts`
+- `tests-d/core/logic.test-d.ts`
+- `tests-d/core/combinators/one-of.test-d.ts`
+- `tests-d/core/compiler-api.test-d.ts`
+- `typescript-compiler-api-design.md`

--- a/src/core/combinators/one-of.ts
+++ b/src/core/combinators/one-of.ts
@@ -1,9 +1,4 @@
 import type { GuardedOf, GuardedWithin, Predicate, Refinement } from '@/types';
-import type {
-  BooleanRefinement,
-  InputOf,
-  RefinementFunction
-} from '../refinement-internals';
 
 /**
  * Combines refinements sharing an input domain.
@@ -17,16 +12,10 @@ export function oneOf<Fs extends readonly Predicate<unknown>[]>(
 export function oneOf<A, Fs extends readonly Predicate<A>[]>(
   ...guards: Fs
 ): (input: A) => input is GuardedWithin<Fs, A>;
-export function oneOf<
-  First extends BooleanRefinement,
-  Rest extends readonly Refinement<InputOf<First>, InputOf<First>>[]
->(
-  first: First & RefinementFunction<First>,
+export function oneOf<A, B extends A, Rest extends readonly Refinement<A, A>[]>(
+  first: Refinement<A, B>,
   ...rest: Rest
-): Refinement<
-  InputOf<First>,
-  Extract<GuardedOf<First> | GuardedOf<Rest[number]>, InputOf<First>>
->;
+): Refinement<A, B | GuardedOf<Rest[number]>>;
 export function oneOf(
   ...refinements: readonly ((input: never) => boolean)[]
 ): (input: never) => boolean {

--- a/src/core/combinators/one-of.ts
+++ b/src/core/combinators/one-of.ts
@@ -1,5 +1,9 @@
 import type { GuardedOf, GuardedWithin, Predicate, Refinement } from '@/types';
-import type { BooleanRefinement, InputOf } from '../refinement-internals';
+import type {
+  BooleanRefinement,
+  InputOf,
+  RefinementFunction
+} from '../refinement-internals';
 
 /**
  * Combines refinements sharing an input domain.
@@ -17,7 +21,7 @@ export function oneOf<
   First extends BooleanRefinement,
   Rest extends readonly Refinement<InputOf<First>, InputOf<First>>[]
 >(
-  first: First,
+  first: First & RefinementFunction<First>,
   ...rest: Rest
 ): Refinement<
   InputOf<First>,

--- a/src/core/combinators/one-of.ts
+++ b/src/core/combinators/one-of.ts
@@ -1,11 +1,17 @@
-import type { GuardedOf, GuardedWithin, Predicate } from '@/types';
-import { or } from '../logic';
+import type { GuardedOf, GuardedWithin, Predicate, Refinement } from '@/types';
+
+// WHY: `never` lets the implementation accept functions from any input domain
+// without falsely claiming that narrow-domain refinements accept `unknown`.
+type BooleanRefinement = (input: never) => boolean;
+
+type InputOf<F> =
+  F extends Refinement<infer Input, infer _Output> ? Input : never;
 
 /**
- * Combines multiple guards; passes when any one guard matches.
+ * Combines refinements sharing an input domain.
  *
- * @param guards One or more type guards/refinements to try.
- * @returns Predicate that narrows to the union of guarded types.
+ * @param refinements One or more refinements to try.
+ * @returns Refinement that narrows to the union of matching types.
  */
 export function oneOf<Fs extends readonly Predicate<unknown>[]>(
   ...guards: Fs
@@ -13,8 +19,18 @@ export function oneOf<Fs extends readonly Predicate<unknown>[]>(
 export function oneOf<A, Fs extends readonly Predicate<A>[]>(
   ...guards: Fs
 ): (input: A) => input is GuardedWithin<Fs, A>;
+export function oneOf<
+  First extends BooleanRefinement,
+  Rest extends readonly Refinement<InputOf<First>, InputOf<First>>[]
+>(
+  first: First,
+  ...rest: Rest
+): Refinement<
+  InputOf<First>,
+  Extract<GuardedOf<First> | GuardedOf<Rest[number]>, InputOf<First>>
+>;
 export function oneOf(
-  ...guards: readonly ((input: unknown) => input is unknown)[]
-) {
-  return or(...guards);
+  ...refinements: readonly ((input: never) => boolean)[]
+): (input: never) => boolean {
+  return (input) => refinements.some((refinement) => refinement(input));
 }

--- a/src/core/combinators/one-of.ts
+++ b/src/core/combinators/one-of.ts
@@ -1,11 +1,5 @@
 import type { GuardedOf, GuardedWithin, Predicate, Refinement } from '@/types';
-
-// WHY: `never` lets the implementation accept functions from any input domain
-// without falsely claiming that narrow-domain refinements accept `unknown`.
-type BooleanRefinement = (input: never) => boolean;
-
-type InputOf<F> =
-  F extends Refinement<infer Input, infer _Output> ? Input : never;
+import type { BooleanRefinement, InputOf } from '../refinement-internals';
 
 /**
  * Combines refinements sharing an input domain.

--- a/src/core/logic.ts
+++ b/src/core/logic.ts
@@ -8,13 +8,7 @@ import type {
   OutOfGuards,
   Predicate
 } from '@/types';
-
-// WHY: `never` lets implementation overloads accept functions from any input
-// domain without falsely claiming that narrow-domain refinements accept `unknown`.
-type BooleanRefinement = (input: never) => boolean;
-
-type InputOf<F> =
-  F extends Refinement<infer Input, infer _Output> ? Input : never;
+import type { BooleanRefinement, InputOf } from './refinement-internals';
 
 /**
  * Combines a precondition refinement with an additional refinement.

--- a/src/core/logic.ts
+++ b/src/core/logic.ts
@@ -8,7 +8,11 @@ import type {
   OutOfGuards,
   Predicate
 } from '@/types';
-import type { BooleanRefinement, InputOf } from './refinement-internals';
+import type {
+  BooleanRefinement,
+  InputOf,
+  RefinementFunction
+} from './refinement-internals';
 
 /**
  * Combines a precondition refinement with an additional refinement.
@@ -33,7 +37,7 @@ export function and<
   Precondition extends BooleanRefinement,
   B extends GuardedOf<Precondition>
 >(
-  precondition: Precondition,
+  precondition: Precondition & RefinementFunction<Precondition>,
   condition: Refine<GuardedOf<Precondition>, B>
 ): Refinement<InputOf<Precondition>, B>;
 export function and(
@@ -70,13 +74,13 @@ export function andAll<A, Chain extends readonly Refine<unknown, unknown>[]>(
   ...steps: Chain & RefineChain<A, Chain>
 ): Guard<ChainResult<A, Chain>>;
 export function andAll<Precondition extends BooleanRefinement>(
-  precondition: Precondition
+  precondition: Precondition & RefinementFunction<Precondition>
 ): Refinement<InputOf<Precondition>, GuardedOf<Precondition>>;
 export function andAll<
   Precondition extends BooleanRefinement,
   B extends GuardedOf<Precondition>
 >(
-  precondition: Precondition,
+  precondition: Precondition & RefinementFunction<Precondition>,
   step1: Refine<GuardedOf<Precondition>, B>
 ): Refinement<InputOf<Precondition>, B>;
 export function andAll<
@@ -84,7 +88,7 @@ export function andAll<
   B extends GuardedOf<Precondition>,
   C extends B
 >(
-  precondition: Precondition,
+  precondition: Precondition & RefinementFunction<Precondition>,
   step1: Refine<GuardedOf<Precondition>, B>,
   step2: Refine<B, C>
 ): Refinement<InputOf<Precondition>, C>;
@@ -92,7 +96,7 @@ export function andAll<
   Precondition extends BooleanRefinement,
   Chain extends readonly unknown[]
 >(
-  precondition: Precondition,
+  precondition: Precondition & RefinementFunction<Precondition>,
   ...steps: Chain & RefineChain<GuardedOf<Precondition>, Chain>
 ): Refinement<
   InputOf<Precondition>,
@@ -126,7 +130,7 @@ export function or<
   First extends BooleanRefinement,
   Rest extends readonly Refinement<InputOf<First>, InputOf<First>>[]
 >(
-  first: First,
+  first: First & RefinementFunction<First>,
   ...rest: Rest
 ): Refinement<
   InputOf<First>,

--- a/src/core/logic.ts
+++ b/src/core/logic.ts
@@ -13,6 +13,7 @@ import type {
   LastOr,
   RefinementsFromOutputs
 } from './refinement-internals';
+import { isFunction } from './object';
 
 /**
  * Combines a precondition refinement with an additional refinement.
@@ -48,6 +49,7 @@ export function and(
  * Chains refinements while preserving the precondition's input domain.
  * Use this instead of nested `&&` checks when each step should keep narrowing
  * the next refinement.
+ * Pass a generic readonly chain as one tuple to preserve its final narrowing.
  *
  * @param precondition Initial guard applied first.
  * @param steps Subsequent refinements applied in order.
@@ -86,6 +88,12 @@ export function andAll<A, B extends A, Chain extends readonly unknown[]>(
   precondition: Refinement<A, B>,
   ...steps: Chain & RefineChain<NoInfer<B>, Chain>
 ): Refinement<A, ChainResult<B, Chain>>;
+// WHY: A readonly tuple argument preserves its generic constraint, while
+// spreading the same unresolved tuple can lose the chain's final output.
+export function andAll<A, B extends A, Outputs extends readonly B[]>(
+  precondition: Refinement<A, B>,
+  steps: RefinementsFromOutputs<NoInfer<B>, Outputs>
+): Refinement<A, LastOr<B, Outputs>>;
 // WHY: Inferring the output tuple lets generic ordered chains prove their
 // relationships without evaluating `RefineChain` against an unresolved tuple.
 export function andAll<A, B extends A, Outputs extends B[]>(
@@ -97,9 +105,17 @@ export function andAll<A, B extends A>(
   ...steps: readonly Refine<NoInfer<B>, NoInfer<B>>[]
 ): Refinement<A, B>;
 export function andAll(
-  precondition: (input: never) => boolean,
-  ...steps: readonly ((input: never) => boolean)[]
-): (input: never) => boolean {
+  precondition: BooleanRefinement,
+  stepOrSteps?: BooleanRefinement | readonly BooleanRefinement[],
+  ...remainingSteps: readonly BooleanRefinement[]
+): BooleanRefinement {
+  const steps =
+    stepOrSteps === undefined
+      ? remainingSteps
+      : isFunction(stepOrSteps)
+        ? [stepOrSteps, ...remainingSteps]
+        : [...stepOrSteps, ...remainingSteps];
+
   return (input) => {
     if (!precondition(input)) return false;
     return steps.every((step) => step(input));

--- a/src/core/logic.ts
+++ b/src/core/logic.ts
@@ -8,11 +8,7 @@ import type {
   OutOfGuards,
   Predicate
 } from '@/types';
-import type {
-  BooleanRefinement,
-  InputOf,
-  RefinementFunction
-} from './refinement-internals';
+import type { BooleanRefinement } from './refinement-internals';
 
 /**
  * Combines a precondition refinement with an additional refinement.
@@ -33,13 +29,10 @@ export function and<A, B extends A>(
   precondition: Guard<A>,
   condition: Refine<A, B>
 ): Predicate<B>;
-export function and<
-  Precondition extends BooleanRefinement,
-  B extends GuardedOf<Precondition>
->(
-  precondition: Precondition & RefinementFunction<Precondition>,
-  condition: Refine<GuardedOf<Precondition>, B>
-): Refinement<InputOf<Precondition>, B>;
+export function and<A, B extends A, C extends B>(
+  precondition: Refinement<A, B>,
+  condition: Refine<NoInfer<B>, C>
+): Refinement<A, C>;
 export function and(
   precondition: BooleanRefinement,
   condition: BooleanRefinement
@@ -73,35 +66,22 @@ export function andAll<A, Chain extends readonly Refine<unknown, unknown>[]>(
   precondition: Guard<A>,
   ...steps: Chain & RefineChain<A, Chain>
 ): Guard<ChainResult<A, Chain>>;
-export function andAll<Precondition extends BooleanRefinement>(
-  precondition: Precondition & RefinementFunction<Precondition>
-): Refinement<InputOf<Precondition>, GuardedOf<Precondition>>;
-export function andAll<
-  Precondition extends BooleanRefinement,
-  B extends GuardedOf<Precondition>
->(
-  precondition: Precondition & RefinementFunction<Precondition>,
-  step1: Refine<GuardedOf<Precondition>, B>
-): Refinement<InputOf<Precondition>, B>;
-export function andAll<
-  Precondition extends BooleanRefinement,
-  B extends GuardedOf<Precondition>,
-  C extends B
->(
-  precondition: Precondition & RefinementFunction<Precondition>,
-  step1: Refine<GuardedOf<Precondition>, B>,
-  step2: Refine<B, C>
-): Refinement<InputOf<Precondition>, C>;
-export function andAll<
-  Precondition extends BooleanRefinement,
-  Chain extends readonly unknown[]
->(
-  precondition: Precondition & RefinementFunction<Precondition>,
-  ...steps: Chain & RefineChain<GuardedOf<Precondition>, Chain>
-): Refinement<
-  InputOf<Precondition>,
-  ChainResult<GuardedOf<Precondition>, Chain>
->;
+export function andAll<A, B extends A>(
+  precondition: Refinement<A, B>
+): Refinement<A, B>;
+export function andAll<A, B extends A, C extends B>(
+  precondition: Refinement<A, B>,
+  step1: Refine<NoInfer<B>, C>
+): Refinement<A, C>;
+export function andAll<A, B extends A, C extends B, D extends C>(
+  precondition: Refinement<A, B>,
+  step1: Refine<NoInfer<B>, C>,
+  step2: Refine<NoInfer<C>, D>
+): Refinement<A, D>;
+export function andAll<A, B extends A, Chain extends readonly unknown[]>(
+  precondition: Refinement<A, B>,
+  ...steps: Chain & RefineChain<NoInfer<B>, Chain>
+): Refinement<A, ChainResult<B, Chain>>;
 export function andAll(
   precondition: (input: never) => boolean,
   ...steps: readonly ((input: never) => boolean)[]
@@ -126,16 +106,10 @@ export function andAll(
 export function or<P extends readonly Guard<unknown>[]>(
   ...guards: P
 ): Guard<OutOfGuards<P>>;
-export function or<
-  First extends BooleanRefinement,
-  Rest extends readonly Refinement<InputOf<First>, InputOf<First>>[]
->(
-  first: First & RefinementFunction<First>,
+export function or<A, B extends A, Rest extends readonly Refinement<A, A>[]>(
+  first: Refinement<A, B>,
   ...rest: Rest
-): Refinement<
-  InputOf<First>,
-  Extract<GuardedOf<First> | GuardedOf<Rest[number]>, InputOf<First>>
->;
+): Refinement<A, B | GuardedOf<Rest[number]>>;
 export function or(
   ...refinements: readonly ((input: never) => boolean)[]
 ): (input: never) => boolean {

--- a/src/core/logic.ts
+++ b/src/core/logic.ts
@@ -78,14 +78,14 @@ export function andAll<A, B extends A, C extends B, D extends C>(
   step1: Refine<NoInfer<B>, C>,
   step2: Refine<NoInfer<C>, D>
 ): Refinement<A, D>;
-export function andAll<A, B extends A>(
-  precondition: Refinement<A, B>,
-  ...steps: readonly Refine<NoInfer<B>, NoInfer<B>>[]
-): Refinement<A, B>;
 export function andAll<A, B extends A, Chain extends readonly unknown[]>(
   precondition: Refinement<A, B>,
   ...steps: Chain & RefineChain<NoInfer<B>, Chain>
 ): Refinement<A, ChainResult<B, Chain>>;
+export function andAll<A, B extends A>(
+  precondition: Refinement<A, B>,
+  ...steps: readonly Refine<NoInfer<B>, NoInfer<B>>[]
+): Refinement<A, B>;
 export function andAll(
   precondition: (input: never) => boolean,
   ...steps: readonly ((input: never) => boolean)[]

--- a/src/core/logic.ts
+++ b/src/core/logic.ts
@@ -1,22 +1,29 @@
 import type {
   Guard,
+  GuardedOf,
   Refine,
   RefineChain,
   ChainResult,
+  Refinement,
   OutOfGuards,
   Predicate
 } from '@/types';
-import { toBooleanPredicates } from '@/utils/to-boolean-predicates';
-import { define } from './define';
+
+// WHY: `never` lets implementation overloads accept functions from any input
+// domain without falsely claiming that narrow-domain refinements accept `unknown`.
+type BooleanRefinement = (input: never) => boolean;
+
+type InputOf<F> =
+  F extends Refinement<infer Input, infer _Output> ? Input : never;
 
 /**
- * Combines a precondition guard with an additional refinement to narrow the type.
+ * Combines a precondition refinement with an additional refinement.
  * Prefer this over hand-written `precondition(x) && condition(x)` when the
- * composed predicate should be reused as a guard.
+ * composed refinement should be reused.
  *
  * @param precondition Broad guard evaluated first; short-circuits on failure.
  * @param condition Refinement evaluated only when `precondition` passes.
- * @returns Predicate that narrows the input to a subtype.
+ * @returns Refinement that preserves the precondition's input domain.
  * @example
  * const isPositiveNumber = and(
  *   isNumber,
@@ -27,23 +34,29 @@ import { define } from './define';
 export function and<A, B extends A>(
   precondition: Guard<A>,
   condition: Refine<A, B>
-): Predicate<B> {
-  return define<B>((input) => {
-    if (precondition(input)) {
-      return condition(input);
-    }
-    return false;
-  });
+): Predicate<B>;
+export function and<
+  Precondition extends BooleanRefinement,
+  B extends GuardedOf<Precondition>
+>(
+  precondition: Precondition,
+  condition: Refine<GuardedOf<Precondition>, B>
+): Refinement<InputOf<Precondition>, B>;
+export function and(
+  precondition: BooleanRefinement,
+  condition: BooleanRefinement
+): BooleanRefinement {
+  return (input) => precondition(input) && condition(input);
 }
 
 /**
- * Chains a sequence of refinements after a precondition, returning the final guard type.
+ * Chains refinements while preserving the precondition's input domain.
  * Use this instead of nested `&&` checks when each step should keep narrowing
  * the next refinement.
  *
  * @param precondition Initial guard applied first.
  * @param steps Subsequent refinements applied in order.
- * @returns Guard reflecting the result of the refinement chain.
+ * @returns Refinement reflecting the final result of the chain.
  * @example
  * const isPublicTitle = andAll(isString, minLength(4), startsWithPublic);
  * @see and
@@ -61,31 +74,74 @@ export function andAll<A, B extends A, C extends B>(
 export function andAll<A, Chain extends readonly Refine<unknown, unknown>[]>(
   precondition: Guard<A>,
   ...steps: Chain & RefineChain<A, Chain>
-): Guard<ChainResult<A, Chain>> {
-  return define<ChainResult<A, Chain>>((input) => {
+): Guard<ChainResult<A, Chain>>;
+export function andAll<Precondition extends BooleanRefinement>(
+  precondition: Precondition
+): Refinement<InputOf<Precondition>, GuardedOf<Precondition>>;
+export function andAll<
+  Precondition extends BooleanRefinement,
+  B extends GuardedOf<Precondition>
+>(
+  precondition: Precondition,
+  step1: Refine<GuardedOf<Precondition>, B>
+): Refinement<InputOf<Precondition>, B>;
+export function andAll<
+  Precondition extends BooleanRefinement,
+  B extends GuardedOf<Precondition>,
+  C extends B
+>(
+  precondition: Precondition,
+  step1: Refine<GuardedOf<Precondition>, B>,
+  step2: Refine<B, C>
+): Refinement<InputOf<Precondition>, C>;
+export function andAll<
+  Precondition extends BooleanRefinement,
+  Chain extends readonly unknown[]
+>(
+  precondition: Precondition,
+  ...steps: Chain & RefineChain<GuardedOf<Precondition>, Chain>
+): Refinement<
+  InputOf<Precondition>,
+  ChainResult<GuardedOf<Precondition>, Chain>
+>;
+export function andAll(
+  precondition: (input: never) => boolean,
+  ...steps: readonly ((input: never) => boolean)[]
+): (input: never) => boolean {
+  return (input) => {
     if (!precondition(input)) return false;
-    return applyRefinements(input, steps);
-  });
+    return steps.every((step) => step(input));
+  };
 }
 
 /**
- * Logical OR over multiple guards.
- * Prefer this over hand-written `guardA(x) || guardB(x)` when the composed
- * predicate should be reused as a guard.
+ * Logical OR over refinements sharing an input domain.
+ * Prefer this over hand-written `refineA(x) || refineB(x)` when the composed
+ * refinement should be reused.
  *
- * @param guards Guards to evaluate; passes if any guard passes.
- * @returns Guard for the union of all guarded types.
+ * @param refinements Refinements to evaluate; passes if any refinement passes.
+ * @returns Refinement for the union of all narrowed types.
  * @example
  * const isId = or(isString, isNumber);
  * @see oneOf
  */
 export function or<P extends readonly Guard<unknown>[]>(
   ...guards: P
-): Guard<OutOfGuards<P>> {
-  const predicates = toBooleanPredicates(guards);
-  return define<OutOfGuards<P>>((input) =>
-    predicates.some((guard) => guard(input))
-  );
+): Guard<OutOfGuards<P>>;
+export function or<
+  First extends BooleanRefinement,
+  Rest extends readonly Refinement<InputOf<First>, InputOf<First>>[]
+>(
+  first: First,
+  ...rest: Rest
+): Refinement<
+  InputOf<First>,
+  Extract<GuardedOf<First> | GuardedOf<Rest[number]>, InputOf<First>>
+>;
+export function or(
+  ...refinements: readonly ((input: never) => boolean)[]
+): (input: never) => boolean {
+  return (input) => refinements.some((refinement) => refinement(input));
 }
 
 /**
@@ -118,25 +174,4 @@ export function not<A, B extends A>(
 ): Refine<A, Exclude<A, B>>;
 export function not(fn: (input: unknown) => boolean) {
   return (input: unknown) => !fn(input);
-}
-
-// WHY: Overloads model refinement chains without casting; the runtime simply
-// applies each refinement in order while preserving short-circuit behavior.
-function applyRefinements<In>(value: In): value is In;
-function applyRefinements<
-  In,
-  Steps extends readonly Refine<unknown, unknown>[]
->(
-  value: In,
-  steps: Steps & RefineChain<In, Steps>
-): value is ChainResult<In, Steps>;
-function applyRefinements(
-  value: unknown,
-  steps?: readonly ((value: unknown) => boolean)[]
-): boolean {
-  if (!steps || steps.length === 0) return true;
-  for (const step of steps) {
-    if (!step(value)) return false;
-  }
-  return true;
 }

--- a/src/core/logic.ts
+++ b/src/core/logic.ts
@@ -8,7 +8,11 @@ import type {
   OutOfGuards,
   Predicate
 } from '@/types';
-import type { BooleanRefinement } from './refinement-internals';
+import type {
+  BooleanRefinement,
+  LastOr,
+  RefinementsFromOutputs
+} from './refinement-internals';
 
 /**
  * Combines a precondition refinement with an additional refinement.
@@ -82,6 +86,12 @@ export function andAll<A, B extends A, Chain extends readonly unknown[]>(
   precondition: Refinement<A, B>,
   ...steps: Chain & RefineChain<NoInfer<B>, Chain>
 ): Refinement<A, ChainResult<B, Chain>>;
+// WHY: Inferring the output tuple lets generic ordered chains prove their
+// relationships without evaluating `RefineChain` against an unresolved tuple.
+export function andAll<A, B extends A, Outputs extends B[]>(
+  precondition: Refinement<A, B>,
+  ...steps: readonly unknown[] & RefinementsFromOutputs<B, Outputs>
+): Refinement<A, LastOr<B, Outputs>>;
 export function andAll<A, B extends A>(
   precondition: Refinement<A, B>,
   ...steps: readonly Refine<NoInfer<B>, NoInfer<B>>[]

--- a/src/core/logic.ts
+++ b/src/core/logic.ts
@@ -78,6 +78,10 @@ export function andAll<A, B extends A, C extends B, D extends C>(
   step1: Refine<NoInfer<B>, C>,
   step2: Refine<NoInfer<C>, D>
 ): Refinement<A, D>;
+export function andAll<A, B extends A>(
+  precondition: Refinement<A, B>,
+  ...steps: readonly Refine<NoInfer<B>, NoInfer<B>>[]
+): Refinement<A, B>;
 export function andAll<A, B extends A, Chain extends readonly unknown[]>(
   precondition: Refinement<A, B>,
   ...steps: Chain & RefineChain<NoInfer<B>, Chain>

--- a/src/core/logic.ts
+++ b/src/core/logic.ts
@@ -46,7 +46,7 @@ export function and(
   precondition: BooleanRefinement,
   condition: BooleanRefinement
 ): BooleanRefinement {
-  return (input) => precondition(input) && condition(input);
+  return (input) => !!(precondition(input) && condition(input));
 }
 
 /**

--- a/src/core/refinement-internals.ts
+++ b/src/core/refinement-internals.ts
@@ -1,13 +1,3 @@
-import type { Refinement } from '@/types';
-
 // WHY: `never` lets implementation overloads accept functions from any input
 // domain without falsely claiming that narrow-domain refinements accept `unknown`.
 export type BooleanRefinement = (input: never) => boolean;
-
-/** Rejects boolean functions that do not declare a type-predicate result. */
-export type RefinementFunction<F> =
-  F extends Refinement<infer _Input, infer _Output> ? F : never;
-
-/** Extracts the accepted input domain from a refinement. */
-export type InputOf<F> =
-  F extends Refinement<infer Input, infer _Output> ? Input : never;

--- a/src/core/refinement-internals.ts
+++ b/src/core/refinement-internals.ts
@@ -4,6 +4,10 @@ import type { Refinement } from '@/types';
 // domain without falsely claiming that narrow-domain refinements accept `unknown`.
 export type BooleanRefinement = (input: never) => boolean;
 
+/** Rejects boolean functions that do not declare a type-predicate result. */
+export type RefinementFunction<F> =
+  F extends Refinement<infer _Input, infer _Output> ? F : never;
+
 /** Extracts the accepted input domain from a refinement. */
 export type InputOf<F> =
   F extends Refinement<infer Input, infer _Output> ? Input : never;

--- a/src/core/refinement-internals.ts
+++ b/src/core/refinement-internals.ts
@@ -1,3 +1,27 @@
+import type { Refinement } from '@/types';
+
 // WHY: `never` lets implementation overloads accept functions from any input
 // domain without falsely claiming that narrow-domain refinements accept `unknown`.
 export type BooleanRefinement = (input: never) => boolean;
+
+type RefinementInputs<In, Outputs extends readonly unknown[]> = readonly [
+  In,
+  ...Outputs
+];
+
+/** Builds an ordered refinement tuple from its initial input and output tuple. */
+export type RefinementsFromOutputs<In, Outputs extends readonly unknown[]> = {
+  [K in keyof Outputs]: Refinement<
+    RefinementInputs<In, Outputs>[K & keyof RefinementInputs<In, Outputs>],
+    Outputs[K] &
+      RefinementInputs<In, Outputs>[K & keyof RefinementInputs<In, Outputs>]
+  >;
+};
+
+/** Returns the last tuple member, or a fallback for an empty tuple. */
+export type LastOr<Default, T extends readonly unknown[]> = T extends readonly [
+  ...unknown[],
+  infer Tail
+]
+  ? Tail
+  : Default;

--- a/src/core/refinement-internals.ts
+++ b/src/core/refinement-internals.ts
@@ -1,0 +1,9 @@
+import type { Refinement } from '@/types';
+
+// WHY: `never` lets implementation overloads accept functions from any input
+// domain without falsely claiming that narrow-domain refinements accept `unknown`.
+export type BooleanRefinement = (input: never) => boolean;
+
+/** Extracts the accepted input domain from a refinement. */
+export type InputOf<F> =
+  F extends Refinement<infer Input, infer _Output> ? Input : never;

--- a/src/types/core.ts
+++ b/src/types/core.ts
@@ -1,8 +1,8 @@
-/** Predicate that accepts an unknown value and narrows it to `T`. */
-export type Predicate<T> = (value: unknown) => value is T;
-
 /** Refinement that narrows a known input type `A` to its subtype `B`. */
 export type Refinement<A, B extends A> = (value: A) => value is B;
+
+/** Predicate that accepts an unknown value and narrows it to `T`. */
+export type Predicate<T> = Refinement<unknown, T>;
 
 /** Readability alias for {@link Predicate}. */
 export type Guard<T> = Predicate<T>;
@@ -34,10 +34,8 @@ export type ParseResult<T> = { valid: true; value: T } | { valid: false };
 /** Function that explicitly transforms an input into a parsed output value. */
 export type Decoder<Input, Output> = (input: Input) => ParseResult<Output>;
 
-/** Extracts the narrowed output type from a predicate. */
-export type GuardedOf<F> = F extends ((value: unknown) => value is infer G)
-  ? G
-  : never;
+/** Extracts the narrowed output type from a predicate or refinement. */
+export type GuardedOf<F> = F extends Refinement<infer A, infer B> ? B : never;
 
 /** Extracts guard outputs that remain assignable to a known input type. */
 export type GuardedWithin<Fs, A> = Extract<

--- a/tests-d/core/combinators/one-of.test-d.ts
+++ b/tests-d/core/combinators/one-of.test-d.ts
@@ -1,7 +1,18 @@
 import { expectType } from 'tsd';
 import { oneOf } from '@/core/combinators';
 import { isString, isNumber } from '@/core/primitive';
-import type { Predicate } from '@/types';
+import type { Predicate, Refine } from '@/types';
+
+type AstNode =
+  | { kind: 'identifier'; text: string }
+  | { kind: 'literal'; value: string }
+  | { kind: 'call' };
+type Identifier = Extract<AstNode, { kind: 'identifier' }>;
+type Literal = Extract<AstNode, { kind: 'literal' }>;
+
+const isIdentifier = (node: AstNode): node is Identifier =>
+  node.kind === 'identifier';
+const isLiteral = (node: AstNode): node is Literal => node.kind === 'literal';
 
 // =============================================
 // describe: oneOf
@@ -10,7 +21,30 @@ import type { Predicate } from '@/types';
 const isStringOrNumber = oneOf(isString, isNumber);
 expectType<Predicate<string | number>>(isStringOrNumber);
 
+// it: preserves the v1 explicit generic tuple parameter
+expectType<Predicate<string | number>>(
+  oneOf<[typeof isString, typeof isNumber]>(isString, isNumber)
+);
+
+// it: preserves the v1 explicit input and tuple parameters
+expectType<Refine<string | number, string | number>>(
+  oneOf<string | number, [typeof isString, typeof isNumber]>(isString, isNumber)
+);
+
 declare const unionCandidate: unknown;
 if (isStringOrNumber(unionCandidate)) {
   expectType<string | number>(unionCandidate);
 }
+
+// it: unions outputs over a shared known input domain
+const isIdentifierOrLiteral = oneOf(isIdentifier, isLiteral);
+expectType<Refine<AstNode, Identifier | Literal>>(isIdentifierOrLiteral);
+
+declare const astNode: AstNode;
+if (isIdentifierOrLiteral(astNode)) {
+  expectType<Identifier | Literal>(astNode);
+}
+
+// it: preserves the empty-call behavior
+expectType<Predicate<never>>(oneOf());
+expectType<Predicate<never>>(oneOf<[]>());

--- a/tests-d/core/combinators/one-of.test-d.ts
+++ b/tests-d/core/combinators/one-of.test-d.ts
@@ -48,3 +48,8 @@ if (isIdentifierOrLiteral(astNode)) {
 // it: preserves the empty-call behavior
 expectType<Predicate<never>>(oneOf());
 expectType<Predicate<never>>(oneOf<[]>());
+
+// it: rejects an ordinary boolean predicate as the first refinement
+const isPositiveBoolean = (value: number): boolean => value > 0;
+// @ts-expect-error: `oneOf` requires a type predicate as its first argument.
+oneOf(isPositiveBoolean);

--- a/tests-d/core/combinators/one-of.test-d.ts
+++ b/tests-d/core/combinators/one-of.test-d.ts
@@ -45,6 +45,16 @@ if (isIdentifierOrLiteral(astNode)) {
   expectType<Identifier | Literal>(astNode);
 }
 
+// it: accepts a generically constrained refinement
+function composeGenerically<
+  A,
+  B extends A,
+  C extends A,
+  F extends Refine<A, B>
+>(refinement: F, alternative: Refine<A, C>) {
+  expectType<Refine<A, B | C>>(oneOf(refinement, alternative));
+}
+
 // it: preserves the empty-call behavior
 expectType<Predicate<never>>(oneOf());
 expectType<Predicate<never>>(oneOf<[]>());

--- a/tests-d/core/compiler-api.test-d.ts
+++ b/tests-d/core/compiler-api.test-d.ts
@@ -1,0 +1,67 @@
+import { expectType } from 'tsd';
+import * as ts from 'typescript';
+import { oneOf } from '@/core/combinators';
+import { and, andAll, or } from '@/core/logic';
+import type { GuardedOf, Refine } from '@/types';
+
+type IdentifierCall = ts.CallExpression & {
+  expression: ts.Identifier;
+};
+
+type RequireCall = IdentifierCall & {
+  expression: ts.Identifier & { text: 'require' };
+};
+
+const hasIdentifierCallee = (node: ts.CallExpression): node is IdentifierCall =>
+  ts.isIdentifier(node.expression);
+
+const hasRequireCallee = (node: IdentifierCall): node is RequireCall =>
+  node.expression.text === 'require';
+
+// =============================================
+// describe: TypeScript Compiler API compatibility
+// =============================================
+// it: extracts outputs from known-domain refinements
+declare const identifier: GuardedOf<typeof ts.isIdentifier>;
+expectType<ts.Identifier>(identifier);
+
+// it: composes a Compiler API guard with a child refinement
+const isIdentifierCall = and(ts.isCallExpression, hasIdentifierCallee);
+expectType<Refine<ts.Node, IdentifierCall>>(isIdentifierCall);
+
+// it: preserves the Compiler API input across a refinement chain
+const isRequireCall = andAll(
+  ts.isCallExpression,
+  hasIdentifierCallee,
+  hasRequireCallee
+);
+expectType<Refine<ts.Node, RequireCall>>(isRequireCall);
+
+// it: unions Compiler API guard outputs with or
+const isStringLike = or(ts.isStringLiteral, ts.isNoSubstitutionTemplateLiteral);
+expectType<
+  Refine<ts.Node, ts.StringLiteral | ts.NoSubstitutionTemplateLiteral>
+>(isStringLike);
+
+// it: unions Compiler API guard outputs with oneOf
+const isNamedDeclaration = oneOf(
+  ts.isClassDeclaration,
+  ts.isFunctionDeclaration,
+  ts.isVariableDeclaration
+);
+expectType<
+  Refine<
+    ts.Node,
+    ts.ClassDeclaration | ts.FunctionDeclaration | ts.VariableDeclaration
+  >
+>(isNamedDeclaration);
+
+declare let node: ts.Node;
+
+if (isRequireCall(node)) {
+  expectType<'require'>(node.expression.text);
+}
+
+if (isStringLike(node)) {
+  expectType<ts.StringLiteral | ts.NoSubstitutionTemplateLiteral>(node);
+}

--- a/tests-d/core/logic.test-d.ts
+++ b/tests-d/core/logic.test-d.ts
@@ -60,6 +60,16 @@ if (identifierCall(astNode)) {
   expectType<Identifier>(astNode.expression);
 }
 
+// it: accepts a generically constrained refinement
+function composeAndGenerically<
+  A,
+  B extends A,
+  C extends B,
+  F extends Refine<A, B>
+>(precondition: F, condition: Refine<B, C>) {
+  expectType<Refine<A, C>>(and(precondition, condition));
+}
+
 // =============================================
 // describe: andAll
 // =============================================
@@ -85,6 +95,17 @@ if (namedIdentifierCall(astNode)) {
   expectType<'run'>(astNode.expression.text);
 }
 
+// it: accepts a generically constrained refinement
+function composeAndAllGenerically<
+  A,
+  B extends A,
+  C extends B,
+  F extends Refine<A, B>
+>(precondition: F, step: Refine<B, C>) {
+  expectType<Refine<A, B>>(andAll(precondition));
+  expectType<Refine<A, C>>(andAll(precondition, step));
+}
+
 // =============================================
 // describe: or
 // =============================================
@@ -107,6 +128,16 @@ expectType<Refine<AstNode, Identifier | Literal>>(identifierOrLiteral);
 
 if (identifierOrLiteral(astNode)) {
   expectType<Identifier | Literal>(astNode);
+}
+
+// it: accepts a generically constrained refinement
+function composeOrGenerically<
+  A,
+  B extends A,
+  C extends A,
+  F extends Refine<A, B>
+>(refinement: F, alternative: Refine<A, C>) {
+  expectType<Refine<A, B | C>>(or(refinement, alternative));
 }
 
 // it: preserves the v1 empty-call return type

--- a/tests-d/core/logic.test-d.ts
+++ b/tests-d/core/logic.test-d.ts
@@ -143,6 +143,33 @@ function composeAndAllArrayGenerically<A, B extends A, F extends Refine<A, B>>(
   expectType<Refine<A, B>>(andAll(precondition, ...steps));
 }
 
+// it: accepts a generic heterogeneous refinement chain
+function composeAndAllChainGenerically<
+  A,
+  B extends A,
+  C extends B,
+  D extends C,
+  E extends D,
+  F extends Refine<A, B>,
+  Steps extends [Refine<B, C>, Refine<C, D>, Refine<D, E>]
+>(precondition: F, steps: Steps) {
+  expectType<Refine<A, E>>(andAll(precondition, ...steps));
+}
+
+// it: accepts longer generic heterogeneous refinement chains
+function composeLongerAndAllChainGenerically<
+  A,
+  B extends A,
+  C extends B,
+  D extends C,
+  E extends D,
+  G extends E,
+  F extends Refine<A, B>,
+  Steps extends [Refine<B, C>, Refine<C, D>, Refine<D, E>, Refine<E, G>]
+>(precondition: F, steps: Steps) {
+  expectType<Refine<A, G>>(andAll(precondition, ...steps));
+}
+
 // =============================================
 // describe: or
 // =============================================
@@ -185,6 +212,8 @@ expectType<Predicate<unknown>>(or<[]>());
 // it: rejects refinements whose output is outside the narrowed input
 // @ts-expect-error: A literal cannot refine a call after `isCall` succeeds.
 and(isCall, isLiteral);
+// @ts-expect-error: Every `andAll` step must refine the preceding output.
+andAll(isCall, hasIdentifierExpression, isLiteral, hasRunExpression);
 
 // it: rejects union refinements with unrelated input domains
 const isStringWithinPrimitive = (value: string | number): value is string =>

--- a/tests-d/core/logic.test-d.ts
+++ b/tests-d/core/logic.test-d.ts
@@ -170,6 +170,19 @@ function composeLongerAndAllChainGenerically<
   expectType<Refine<A, G>>(andAll(precondition, ...steps));
 }
 
+// it: preserves narrowing for a readonly generic chain passed as a tuple
+function composeReadonlyAndAllChainGenerically<
+  A,
+  B extends A,
+  C extends B,
+  D extends C,
+  E extends D,
+  F extends Refine<A, B>,
+  Steps extends readonly [Refine<B, C>, Refine<C, D>, Refine<D, E>]
+>(precondition: F, steps: Steps) {
+  expectType<Refine<A, E>>(andAll(precondition, steps));
+}
+
 // =============================================
 // describe: or
 // =============================================
@@ -214,6 +227,8 @@ expectType<Predicate<unknown>>(or<[]>());
 and(isCall, isLiteral);
 // @ts-expect-error: Every `andAll` step must refine the preceding output.
 andAll(isCall, hasIdentifierExpression, isLiteral, hasRunExpression);
+// @ts-expect-error: A readonly tuple must also refine each preceding output.
+andAll(isCall, [hasIdentifierExpression, isLiteral, hasRunExpression] as const);
 
 // it: rejects union refinements with unrelated input domains
 const isStringWithinPrimitive = (value: string | number): value is string =>

--- a/tests-d/core/logic.test-d.ts
+++ b/tests-d/core/logic.test-d.ts
@@ -81,6 +81,25 @@ const namedIdentifierCall = andAll(
 );
 expectType<Refine<AstNode, NamedIdentifierCall>>(namedIdentifierCall);
 
+// it: prefers tuple narrowing when every step accepts the original domain
+type PipelineDomain = { level: 1 | 2 | 3 | 4 };
+type PipelineFirst = { level: 1 | 2 | 3 };
+type PipelineSecond = { level: 1 | 2 };
+type PipelineFinal = { level: 1 };
+type PipelineInput = PipelineDomain | string;
+declare const isPipelineDomain: Refine<PipelineInput, PipelineDomain>;
+declare const narrowsPipelineFirst: Refine<PipelineDomain, PipelineFirst>;
+declare const narrowsPipelineSecond: Refine<PipelineDomain, PipelineSecond>;
+declare const narrowsPipelineFinal: Refine<PipelineDomain, PipelineFinal>;
+const pipelineSteps = [
+  narrowsPipelineFirst,
+  narrowsPipelineSecond,
+  narrowsPipelineFinal
+] as const;
+expectType<Refine<PipelineInput, PipelineFinal>>(
+  andAll(isPipelineDomain, ...pipelineSteps)
+);
+
 // it: preserves the v1 explicit generic parameters
 expectType<Predicate<string>>(andAll<string>(isString));
 expectType<Predicate<'a'>>(andAll<string, 'a'>(isString, isLiteralA));

--- a/tests-d/core/logic.test-d.ts
+++ b/tests-d/core/logic.test-d.ts
@@ -124,6 +124,16 @@ const isStringWithinPrimitive = (value: string | number): value is string =>
 // @ts-expect-error: Every `or` branch must accept the first branch's input domain.
 or(isIdentifier, isStringWithinPrimitive);
 
+// it: rejects ordinary boolean predicates as the first refinement
+const isPositiveBoolean = (value: number): boolean => value > 0;
+const rejectsEveryNever = (value: never): value is never => false;
+// @ts-expect-error: `and` requires a type predicate as its precondition.
+and(isPositiveBoolean, rejectsEveryNever);
+// @ts-expect-error: `andAll` requires a type predicate as its precondition.
+andAll(isPositiveBoolean);
+// @ts-expect-error: `or` requires a type predicate as its first argument.
+or(isPositiveBoolean);
+
 // =============================================
 // describe: guardIn
 // =============================================

--- a/tests-d/core/logic.test-d.ts
+++ b/tests-d/core/logic.test-d.ts
@@ -1,6 +1,7 @@
 import { expectType } from 'tsd';
 import {
   and,
+  andAll,
   or,
   guardIn,
   not,
@@ -9,6 +10,27 @@ import {
   define
 } from '../../src/core';
 import type { Predicate, Refine } from '../../src/types';
+
+type AstNode =
+  | { kind: 'identifier'; text: string }
+  | { kind: 'literal'; value: string }
+  | { kind: 'call'; expression: AstNode };
+type Identifier = Extract<AstNode, { kind: 'identifier' }>;
+type Literal = Extract<AstNode, { kind: 'literal' }>;
+type Call = Extract<AstNode, { kind: 'call' }>;
+type IdentifierCall = Call & { expression: Identifier };
+type NamedIdentifierCall = IdentifierCall & {
+  expression: Identifier & { text: 'run' };
+};
+
+const isIdentifier = (node: AstNode): node is Identifier =>
+  node.kind === 'identifier';
+const isLiteral = (node: AstNode): node is Literal => node.kind === 'literal';
+const isCall = (node: AstNode): node is Call => node.kind === 'call';
+const hasIdentifierExpression = (node: Call): node is IdentifierCall =>
+  isIdentifier(node.expression);
+const hasRunExpression = (node: IdentifierCall): node is NamedIdentifierCall =>
+  node.expression.text === 'run';
 
 // =============================================
 // describe: and
@@ -20,13 +42,48 @@ const isLiteralA = define<'a'>(
 const stringAndLiteralAGuard = and(isString, isLiteralA);
 expectType<Predicate<'a'>>(stringAndLiteralAGuard);
 
+// it: preserves the v1 explicit generic parameters
+expectType<Predicate<'a'>>(and<string, 'a'>(isString, isLiteralA));
+
 declare let unknownCandidate: unknown;
 // it: narrows unknown inside control-flow
 if (stringAndLiteralAGuard(unknownCandidate)) {
   expectType<'a'>(unknownCandidate);
 }
 
-// Note: andAll covered in runtime tests (varargs inference is brittle)
+// it: preserves a known input domain
+const identifierCall = and(isCall, hasIdentifierExpression);
+expectType<Refine<AstNode, IdentifierCall>>(identifierCall);
+
+declare let astNode: AstNode;
+if (identifierCall(astNode)) {
+  expectType<Identifier>(astNode.expression);
+}
+
+// =============================================
+// describe: andAll
+// =============================================
+// it: preserves a known input domain across a refinement chain
+const namedIdentifierCall = andAll(
+  isCall,
+  hasIdentifierExpression,
+  hasRunExpression
+);
+expectType<Refine<AstNode, NamedIdentifierCall>>(namedIdentifierCall);
+
+// it: preserves the v1 explicit generic parameters
+expectType<Predicate<string>>(andAll<string>(isString));
+expectType<Predicate<'a'>>(andAll<string, 'a'>(isString, isLiteralA));
+expectType<Predicate<'a'>>(
+  andAll<string, 'a', 'a'>(isString, isLiteralA, isLiteralA)
+);
+expectType<Predicate<'a'>>(
+  andAll<string, [typeof isLiteralA]>(isString, isLiteralA)
+);
+
+if (namedIdentifierCall(astNode)) {
+  expectType<'run'>(astNode.expression.text);
+}
 
 // =============================================
 // describe: or
@@ -35,9 +92,37 @@ if (stringAndLiteralAGuard(unknownCandidate)) {
 const stringOrNumberGuard = or(isString, isNumber);
 expectType<Predicate<string | number>>(stringOrNumberGuard);
 
+// it: preserves the v1 explicit generic tuple parameter
+expectType<Predicate<string | number>>(
+  or<[typeof isString, typeof isNumber]>(isString, isNumber)
+);
+
 if (stringOrNumberGuard(unknownCandidate)) {
   expectType<string | number>(unknownCandidate);
 }
+
+// it: unions outputs over a shared known input domain
+const identifierOrLiteral = or(isIdentifier, isLiteral);
+expectType<Refine<AstNode, Identifier | Literal>>(identifierOrLiteral);
+
+if (identifierOrLiteral(astNode)) {
+  expectType<Identifier | Literal>(astNode);
+}
+
+// it: preserves the v1 empty-call return type
+// Note: Runtime always returns false, but narrowing it to `never` is a v2 change.
+expectType<Predicate<unknown>>(or());
+expectType<Predicate<unknown>>(or<[]>());
+
+// it: rejects refinements whose output is outside the narrowed input
+// @ts-expect-error: A literal cannot refine a call after `isCall` succeeds.
+and(isCall, isLiteral);
+
+// it: rejects union refinements with unrelated input domains
+const isStringWithinPrimitive = (value: string | number): value is string =>
+  typeof value === 'string';
+// @ts-expect-error: Every `or` branch must accept the first branch's input domain.
+or(isIdentifier, isStringWithinPrimitive);
 
 // =============================================
 // describe: guardIn

--- a/tests-d/core/logic.test-d.ts
+++ b/tests-d/core/logic.test-d.ts
@@ -106,6 +106,24 @@ function composeAndAllGenerically<
   expectType<Refine<A, C>>(andAll(precondition, step));
 }
 
+// it: accepts a generic homogeneous refinement tuple
+function composeAndAllTupleGenerically<
+  A,
+  B extends A,
+  F extends Refine<A, B>,
+  Steps extends readonly Refine<B, B>[]
+>(precondition: F, steps: Steps) {
+  expectType<Refine<A, B>>(andAll(precondition, ...steps));
+}
+
+// it: accepts a homogeneous refinement array
+function composeAndAllArrayGenerically<A, B extends A, F extends Refine<A, B>>(
+  precondition: F,
+  steps: Refine<B, B>[]
+) {
+  expectType<Refine<A, B>>(andAll(precondition, ...steps));
+}
+
 // =============================================
 // describe: or
 // =============================================

--- a/tests/core/combinators/one-of.test.ts
+++ b/tests/core/combinators/one-of.test.ts
@@ -15,4 +15,33 @@ describe('oneOf', () => {
     expect(isStringOrNumber(true)).toBe(false);
     expect(isStringOrNumber(null)).toBe(false);
   });
+
+  it('should compose refinements over a shared known input domain', () => {
+    type AstNode =
+      | { kind: 'identifier'; text: string }
+      | { kind: 'literal'; value: string }
+      | { kind: 'call' };
+    type Identifier = Extract<AstNode, { kind: 'identifier' }>;
+    type Literal = Extract<AstNode, { kind: 'literal' }>;
+
+    const isIdentifier = (node: AstNode): node is Identifier =>
+      node.kind === 'identifier';
+    const isLiteral = (node: AstNode): node is Literal =>
+      node.kind === 'literal';
+    const isIdentifierOrLiteral = oneOf(isIdentifier, isLiteral);
+
+    expect(isIdentifierOrLiteral({ kind: 'identifier', text: 'name' })).toBe(
+      true
+    );
+    expect(isIdentifierOrLiteral({ kind: 'literal', value: 'text' })).toBe(
+      true
+    );
+    expect(isIdentifierOrLiteral({ kind: 'call' })).toBe(false);
+  });
+
+  it('should reject every value when no refinements are provided', () => {
+    const never = oneOf();
+
+    expect(never('value')).toBe(false);
+  });
 });

--- a/tests/core/logic.test.ts
+++ b/tests/core/logic.test.ts
@@ -31,6 +31,33 @@ describe('and', () => {
     );
     expect(isNamedIdentifier({ kind: 'literal', value: 'name' })).toBe(false);
   });
+
+  it('coerces truthy and falsy predicate results to booleans', () => {
+    type LoosePredicate = (input: unknown) => unknown;
+    const composeLoose = and as unknown as (
+      precondition: LoosePredicate,
+      condition: LoosePredicate
+    ) => LoosePredicate;
+
+    expect(
+      composeLoose(
+        () => 'truthy',
+        () => ({ matched: true })
+      )('value')
+    ).toBe(true);
+    expect(
+      composeLoose(
+        () => 1,
+        () => 0
+      )('value')
+    ).toBe(false);
+    expect(
+      composeLoose(
+        () => undefined,
+        () => 'truthy'
+      )('value')
+    ).toBe(false);
+  });
 });
 
 describe('andAll', () => {

--- a/tests/core/logic.test.ts
+++ b/tests/core/logic.test.ts
@@ -11,6 +11,26 @@ describe('and', () => {
     expect(isAString('zzz')).toBe(false);
     expect(isAString(123 as unknown)).toBe(false);
   });
+
+  it('composes refinements over a known input domain', () => {
+    type AstNode =
+      | { kind: 'identifier'; text: string }
+      | { kind: 'literal'; value: string };
+    type Identifier = Extract<AstNode, { kind: 'identifier' }>;
+    type NamedIdentifier = Identifier & { text: 'name' };
+
+    const isIdentifier = (node: AstNode): node is Identifier =>
+      node.kind === 'identifier';
+    const isNamed = (node: Identifier): node is NamedIdentifier =>
+      node.text === 'name';
+    const isNamedIdentifier = and(isIdentifier, isNamed);
+
+    expect(isNamedIdentifier({ kind: 'identifier', text: 'name' })).toBe(true);
+    expect(isNamedIdentifier({ kind: 'identifier', text: 'other' })).toBe(
+      false
+    );
+    expect(isNamedIdentifier({ kind: 'literal', value: 'name' })).toBe(false);
+  });
 });
 
 describe('andAll', () => {
@@ -22,6 +42,35 @@ describe('andAll', () => {
     expect(guard(8)).toBe(true);
     expect(guard(6)).toBe(false); // even but not multiple of 4
     expect(guard('8' as unknown)).toBe(false);
+  });
+
+  it('preserves short-circuiting for a known input domain', () => {
+    type AstNode =
+      | { kind: 'call'; expression: string }
+      | { kind: 'literal'; value: string };
+    type Call = Extract<AstNode, { kind: 'call' }>;
+    type NamedCall = Call & { expression: 'run' };
+
+    const isCall = jest.fn(
+      (node: AstNode): node is Call => node.kind === 'call'
+    );
+    const isNamedCall = jest.fn(
+      (node: Call): node is NamedCall => node.expression === 'run'
+    );
+    const isRunnable = jest.fn(
+      (node: NamedCall): node is NamedCall => node.expression.length > 0
+    );
+    const guard = andAll(isCall, isNamedCall, isRunnable);
+
+    expect(guard({ kind: 'literal', value: 'run' })).toBe(false);
+    expect(isNamedCall).not.toHaveBeenCalled();
+    expect(isRunnable).not.toHaveBeenCalled();
+
+    expect(guard({ kind: 'call', expression: 'other' })).toBe(false);
+    expect(isRunnable).not.toHaveBeenCalled();
+
+    expect(guard({ kind: 'call', expression: 'run' })).toBe(true);
+    expect(isRunnable).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -39,6 +88,35 @@ describe('or', () => {
     expect(smallOrShort(7)).toBe(true);
     expect(smallOrShort('toolong')).toBe(false);
     expect(smallOrShort(100)).toBe(false);
+  });
+
+  it('composes refinements over a shared known input domain', () => {
+    type AstNode =
+      | { kind: 'identifier'; text: string }
+      | { kind: 'literal'; value: string }
+      | { kind: 'call' };
+    type Identifier = Extract<AstNode, { kind: 'identifier' }>;
+    type Literal = Extract<AstNode, { kind: 'literal' }>;
+
+    const isIdentifier = (node: AstNode): node is Identifier =>
+      node.kind === 'identifier';
+    const isLiteral = (node: AstNode): node is Literal =>
+      node.kind === 'literal';
+    const isIdentifierOrLiteral = or(isIdentifier, isLiteral);
+
+    expect(isIdentifierOrLiteral({ kind: 'identifier', text: 'name' })).toBe(
+      true
+    );
+    expect(isIdentifierOrLiteral({ kind: 'literal', value: 'text' })).toBe(
+      true
+    );
+    expect(isIdentifierOrLiteral({ kind: 'call' })).toBe(false);
+  });
+
+  it('rejects every value when no refinements are provided', () => {
+    const never = or();
+
+    expect(never('value')).toBe(false);
   });
 });
 

--- a/tests/core/logic.test.ts
+++ b/tests/core/logic.test.ts
@@ -71,6 +71,17 @@ describe('andAll', () => {
     expect(guard('8' as unknown)).toBe(false);
   });
 
+  it('accepts a readonly refinement tuple', () => {
+    const isEven = predicateToRefine<number>((n) => n % 2 === 0);
+    const isMultipleOf4 = predicateToRefine<number>((n) => n % 4 === 0);
+    const steps = [isEven, isMultipleOf4] as const;
+    const guard = andAll(isNumber, steps);
+
+    expect(guard(8)).toBe(true);
+    expect(guard(6)).toBe(false);
+    expect(guard('8' as unknown)).toBe(false);
+  });
+
   it('preserves short-circuiting for a known input domain', () => {
     type AstNode =
       | { kind: 'call'; expression: string }


### PR DESCRIPTION
## Summary

Support known-domain refinement composition 🚀 

<!-- A brief summary of the changes -->

## Description

- allow `and` and `andAll` to compose refinements over known input domains
- allow `or` and `oneOf` to union compatible known-domain refinements
- extend `GuardedOf` to extract outputs from guards and refinements
- preserve v1 overloads, explicit generic calls, and existing `or()` typing

<!-- A detailed explanation of the changes, including why they are needed -->
