### PR TITLE
refactor(docs): extract shared guide components

### DIFF
--- a/docs/app/guides/filter-null-and-undefined/page.tsx
+++ b/docs/app/guides/filter-null-and-undefined/page.tsx
@@ -1,7 +1,13 @@
 import { CodeBlock } from '@/components/code/code-block';
-import { Heading } from '@/components/ui/heading';
+import {
+  GuideArticle,
+  GuideCallout,
+  GuideHeader,
+  GuideList,
+  GuideSection
+} from '@/components/guides/guide-layout';
+import { GuideTable } from '@/components/guides/guide-table';
 import { Paragraph } from '@/components/ui/paragraph';
-import { Stack } from '@/components/ui/stack';
 import { TextLink } from '@/components/ui/text-link';
 import { GUIDE_PATHS } from '@/constants/guides';
 import { API_REFERENCE_PATHS } from '@/lib/api-metadata';
@@ -90,39 +96,14 @@ if (isNotNil(value)) {
 
 export default function FilterNullAndUndefinedGuidePage() {
   return (
-    <Stack
-      variant='article'
-      className='container mx-auto max-w-4xl px-4 py-10'
-      gap='xl'
-    >
-      <Stack variant='section' gap='sm' className='border-b pb-8'>
-        <nav aria-label='Breadcrumb'>
-          <ol className='flex items-center gap-2 text-sm font-medium tracking-[0.14em] uppercase text-primary/70'>
-            <li>
-              <TextLink href={GUIDE_PATHS.index} className='text-inherit'>
-                Guides
-              </TextLink>
-            </li>
-            <li aria-hidden='true'>/</li>
-            <li aria-current='page'>Filter nullish values</li>
-          </ol>
-        </nav>
-        <Heading
-          variant='h1'
-          className='max-w-3xl leading-tight tracking-tight'
-        >
-          How to Safely Filter null and undefined from Arrays in TypeScript
-        </Heading>
-        <Paragraph variant='lead' className='max-w-3xl text-primary/80'>
-          Remove nullish values, preserve valid falsy values, and let TypeScript
-          infer the array you actually have.
-        </Paragraph>
-      </Stack>
+    <GuideArticle>
+      <GuideHeader
+        breadcrumbLabel='Filter nullish values'
+        title='How to Safely Filter null and undefined from Arrays in TypeScript'
+        description='Remove nullish values, preserve valid falsy values, and let TypeScript infer the array you actually have.'
+      />
 
-      <Stack variant='section' gap='md'>
-        <Heading variant='h2' className='text-2xl tracking-tight'>
-          The quick answer
-        </Heading>
+      <GuideSection title='The quick answer'>
         <Paragraph>
           Pass <code>isNotNil</code> directly to <code>Array.filter</code>.
         </Paragraph>
@@ -137,12 +118,9 @@ export default function FilterNullAndUndefinedGuidePage() {
           That is the whole solution. But the common alternatives are worth
           understanding, because they do not all mean the same thing.
         </Paragraph>
-      </Stack>
+      </GuideSection>
 
-      <Stack variant='section' gap='md'>
-        <Heading variant='h2' className='text-2xl tracking-tight'>
-          The tempting shortcut: filter(Boolean)
-        </Heading>
+      <GuideSection title='The tempting shortcut: filter(Boolean)'>
         <Paragraph>You may already have code like this:</Paragraph>
         <CodeBlock code={booleanShortcut} language='ts' />
         <Paragraph>This works.</Paragraph>
@@ -153,16 +131,13 @@ export default function FilterNullAndUndefinedGuidePage() {
           strings, zero, and <code>false</code>. It also does not communicate a
           nullish-specific type predicate to <code>Array.filter</code>.
         </Paragraph>
-        <blockquote className='border-l-2 border-primary/70 py-1 pl-5 text-lg leading-relaxed'>
+        <GuideCallout>
           “Remove nullish values” and “remove every falsy value” are different
           requirements.
-        </blockquote>
-      </Stack>
+        </GuideCallout>
+      </GuideSection>
 
-      <Stack variant='section' gap='md'>
-        <Heading variant='h2' className='text-2xl tracking-tight'>
-          Preserve valid falsy values
-        </Heading>
+      <GuideSection title='Preserve valid falsy values'>
         <Paragraph>
           A value does not become missing just because JavaScript considers it
           falsy.
@@ -177,12 +152,9 @@ export default function FilterNullAndUndefinedGuidePage() {
           <code>isNotNil</code> rejects exactly two values: <code>null</code>{' '}
           and <code>undefined</code>.
         </Paragraph>
-      </Stack>
+      </GuideSection>
 
-      <Stack variant='section' gap='md'>
-        <Heading variant='h2' className='text-2xl tracking-tight'>
-          The explicit inline version
-        </Heading>
+      <GuideSection title='The explicit inline version'>
         <Paragraph>
           You do not need a library for a one-off check. An explicit type
           predicate is perfectly valid TypeScript.
@@ -197,12 +169,9 @@ export default function FilterNullAndUndefinedGuidePage() {
           generic, it preserves whatever non-nullish union each array already
           contains.
         </Paragraph>
-      </Stack>
+      </GuideSection>
 
-      <Stack variant='section' gap='md'>
-        <Heading variant='h2' className='text-2xl tracking-tight'>
-          A practical object example
-        </Heading>
+      <GuideSection title='A practical object example'>
         <Paragraph>
           Nullable values often appear after mapping an object property.
         </Paragraph>
@@ -211,16 +180,13 @@ export default function FilterNullAndUndefinedGuidePage() {
           The guard is still just a function. It works naturally at the normal
           control-flow point where the nullable values appear.
         </Paragraph>
-        <blockquote className='border-l-2 border-primary/70 py-1 pl-5 text-lg leading-relaxed font-semibold'>
+        <GuideCallout emphasized>
           Build small guards, then reuse them where TypeScript narrowing
           matters.
-        </blockquote>
-      </Stack>
+        </GuideCallout>
+      </GuideSection>
 
-      <Stack variant='section' gap='md'>
-        <Heading variant='h2' className='text-2xl tracking-tight'>
-          isNil and isNotNil
-        </Heading>
+      <GuideSection title='isNil and isNotNil'>
         <Paragraph>
           Use <code>isNotNil</code> when you want the non-nullish values. Use{' '}
           <code>isNil</code> when you want to handle the missing branch itself.
@@ -235,58 +201,47 @@ export default function FilterNullAndUndefinedGuidePage() {
           </TextLink>
           .
         </Paragraph>
-      </Stack>
+      </GuideSection>
 
-      <Stack variant='section' gap='md'>
-        <Heading variant='h2' className='text-2xl tracking-tight'>
-          Which approach should you use?
-        </Heading>
-        <div className='overflow-x-auto rounded-md border'>
-          <table className='w-full min-w-2xl border-collapse text-left text-sm'>
-            <thead>
-              <tr className='border-b bg-primary/5'>
-                <th className='px-4 py-3 font-semibold tracking-wide'>
-                  Approach
-                </th>
-                <th className='px-4 py-3 font-semibold tracking-wide'>
-                  Best for
-                </th>
-                <th className='px-4 py-3 font-semibold tracking-wide'>
-                  Watch out for
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr className='border-b'>
-                <td className='px-4 py-3'>filter(Boolean)</td>
-                <td className='px-4 py-3'>Removing every falsy value</td>
-                <td className='px-4 py-3'>Also removes 0, false, and ''</td>
-              </tr>
-              <tr className='border-b'>
-                <td className='px-4 py-3'>Inline predicate</td>
-                <td className='px-4 py-3'>A local, one-off check</td>
-                <td className='px-4 py-3'>Repeats easily across a codebase</td>
-              </tr>
-              <tr>
-                <td className='px-4 py-3'>filter(isNotNil)</td>
-                <td className='px-4 py-3'>Reusable nullish filtering</td>
-                <td className='px-4 py-3'>Requires importing is-kit</td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
+      <GuideSection title='Which approach should you use?'>
+        <GuideTable
+          columns={['Approach', 'Best for', 'Watch out for']}
+          rows={[
+            {
+              key: 'filter-boolean',
+              cells: [
+                'filter(Boolean)',
+                'Removing every falsy value',
+                "Also removes 0, false, and ''"
+              ]
+            },
+            {
+              key: 'inline-predicate',
+              cells: [
+                'Inline predicate',
+                'A local, one-off check',
+                'Repeats easily across a codebase'
+              ]
+            },
+            {
+              key: 'filter-is-not-nil',
+              cells: [
+                'filter(isNotNil)',
+                'Reusable nullish filtering',
+                'Requires importing is-kit'
+              ]
+            }
+          ]}
+        />
         <Paragraph>
           There is no need to turn every inline condition into an abstraction.
           Use <code>isNotNil</code> when the shared meaning and reusable
           narrowing make the call site clearer.
         </Paragraph>
-      </Stack>
+      </GuideSection>
 
-      <Stack variant='section' gap='md' className='border-t pt-8'>
-        <Heading variant='h2' className='text-2xl tracking-tight'>
-          Summary
-        </Heading>
-        <ul className='list-disc space-y-2 pl-6'>
+      <GuideSection title='Summary' className='border-t pt-8'>
+        <GuideList>
           <li>
             Use <code>filter(isNotNil)</code> to remove <code>null</code> and{' '}
             <code>undefined</code> while narrowing the result.
@@ -300,12 +255,12 @@ export default function FilterNullAndUndefinedGuidePage() {
             Prefer a named guard when the same runtime meaning appears in more
             than one place.
           </li>
-        </ul>
+        </GuideList>
         <Paragraph>
           The goal is not shorter syntax alone. It is making “present value”
           mean the same thing everywhere your TypeScript application needs it.
         </Paragraph>
-      </Stack>
-    </Stack>
+      </GuideSection>
+    </GuideArticle>
   );
 }

--- a/docs/app/guides/keep-type-guards-in-sync/page.tsx
+++ b/docs/app/guides/keep-type-guards-in-sync/page.tsx
@@ -1,7 +1,13 @@
 import { CodeBlock } from '@/components/code/code-block';
-import { Heading } from '@/components/ui/heading';
+import {
+  GuideArticle,
+  GuideCallout,
+  GuideHeader,
+  GuideList,
+  GuideSection
+} from '@/components/guides/guide-layout';
+import { GuideTable } from '@/components/guides/guide-table';
 import { Paragraph } from '@/components/ui/paragraph';
-import { Stack } from '@/components/ui/stack';
 import { TextLink } from '@/components/ui/text-link';
 import { GUIDE_PATHS } from '@/constants/guides';
 import { API_REFERENCE_PATHS } from '@/lib/api-metadata';
@@ -153,39 +159,14 @@ isExactUser({ id: 'user-1', name: 'Ada', debug: true }); // false`;
 
 export default function KeepTypeGuardsInSyncGuidePage() {
   return (
-    <Stack
-      variant='article'
-      className='container mx-auto max-w-4xl px-4 py-10'
-      gap='xl'
-    >
-      <Stack variant='section' gap='sm' className='border-b pb-8'>
-        <nav aria-label='Breadcrumb'>
-          <ol className='flex items-center gap-2 text-sm font-medium tracking-[0.14em] uppercase text-primary/70'>
-            <li>
-              <TextLink href={GUIDE_PATHS.index} className='text-inherit'>
-                Guides
-              </TextLink>
-            </li>
-            <li aria-hidden='true'>/</li>
-            <li aria-current='page'>Sync type guards</li>
-          </ol>
-        </nav>
-        <Heading
-          variant='h1'
-          className='max-w-3xl leading-tight tracking-tight'
-        >
-          How to Keep Hand-Written Type Guards in Sync with TypeScript Types
-        </Heading>
-        <Paragraph variant='lead' className='max-w-3xl text-primary/80'>
-          Start with the type you already have, write the runtime checks by
-          hand, and make structural drift a compile-time error.
-        </Paragraph>
-      </Stack>
+    <GuideArticle>
+      <GuideHeader
+        breadcrumbLabel='Sync type guards'
+        title='How to Keep Hand-Written Type Guards in Sync with TypeScript Types'
+        description='Start with the type you already have, write the runtime checks by hand, and make structural drift a compile-time error.'
+      />
 
-      <Stack variant='section' gap='md'>
-        <Heading variant='h2' className='text-2xl tracking-tight'>
-          The quick answer
-        </Heading>
+      <GuideSection title='The quick answer'>
         <Paragraph>
           Pass your existing object type to <code>typedStruct</code>, then
           define one guard for every string-keyed field.
@@ -201,12 +182,9 @@ export default function KeepTypeGuardsInSyncGuidePage() {
           The guards are still explicit. The useful part is that the compiler
           now knows which type they are supposed to follow.
         </Paragraph>
-      </Stack>
+      </GuideSection>
 
-      <Stack variant='section' gap='md'>
-        <Heading variant='h2' className='text-2xl tracking-tight'>
-          Why a type predicate can drift silently
-        </Heading>
+      <GuideSection title='Why a type predicate can drift silently'>
         <Paragraph>
           A hand-written predicate often starts small. Then the application type
           gains a field, while the runtime check stays unchanged.
@@ -217,16 +195,13 @@ export default function KeepTypeGuardsInSyncGuidePage() {
           <code>value is User</code> is a promise made by your function, not a
           proof derived from its body.
         </Paragraph>
-        <blockquote className='border-l-2 border-primary/70 py-1 pl-5 text-lg leading-relaxed'>
+        <GuideCallout>
           The compiler can check a guard’s declared type. It cannot prove that
           arbitrary runtime logic checks every field.
-        </blockquote>
-      </Stack>
+        </GuideCallout>
+      </GuideSection>
 
-      <Stack variant='section' gap='md'>
-        <Heading variant='h2' className='text-2xl tracking-tight'>
-          Make string-keyed structural drift visible
-        </Heading>
+      <GuideSection title='Make string-keyed structural drift visible'>
         <Paragraph>
           For ordinary string-keyed object shapes,{' '}
           <code>typedStruct&lt;User&gt;()</code> turns the object type into a
@@ -243,18 +218,15 @@ export default function KeepTypeGuardsInSyncGuidePage() {
           This does not remove maintenance. It moves forgotten maintenance from
           production behavior into a compiler error.
         </Paragraph>
-        <blockquote className='border-l-2 border-primary/70 py-1 pl-5 text-lg leading-relaxed'>
+        <GuideCallout>
           This drift guarantee is limited to string-keyed properties. Numeric
           and symbol properties are excluded from <code>TypedStructShape</code>,
           so they are not required in the field map and cannot be validated by
           the resulting <code>typedStruct</code> guard.
-        </blockquote>
-      </Stack>
+        </GuideCallout>
+      </GuideSection>
 
-      <Stack variant='section' gap='md'>
-        <Heading variant='h2' className='text-2xl tracking-tight'>
-          Keep optional keys explicit
-        </Heading>
+      <GuideSection title='Keep optional keys explicit'>
         <Paragraph>
           Optional string-keyed object properties must still appear in the field
           map. Wrap them with <code>optionalKey</code> so the key may be absent
@@ -272,12 +244,9 @@ export default function KeepTypeGuardsInSyncGuidePage() {
           optional string-keyed property is added to <code>User</code>, the
           guard should not ignore it silently.
         </Paragraph>
-      </Stack>
+      </GuideSection>
 
-      <Stack variant='section' gap='md'>
-        <Heading variant='h2' className='text-2xl tracking-tight'>
-          Compose nested existing types
-        </Heading>
+      <GuideSection title='Compose nested existing types'>
         <Paragraph>
           For nested objects, define a focused guard from the corresponding
           property type and compose it into the parent guard.
@@ -288,16 +257,13 @@ export default function KeepTypeGuardsInSyncGuidePage() {
           connected to the original type without copying the object shape into
           another TypeScript alias.
         </Paragraph>
-        <blockquote className='border-l-2 border-primary/70 py-1 pl-5 text-lg leading-relaxed font-semibold'>
+        <GuideCallout emphasized>
           Reuse the existing type at compile time. Compose small guards at
           runtime.
-        </blockquote>
-      </Stack>
+        </GuideCallout>
+      </GuideSection>
 
-      <Stack variant='section' gap='md'>
-        <Heading variant='h2' className='text-2xl tracking-tight'>
-          Compile-time fields and runtime extra keys
-        </Heading>
+      <GuideSection title='Compile-time fields and runtime extra keys'>
         <Paragraph>
           <code>typedStruct</code> rejects extra string-keyed fields in the
           guard definition. Extra keys in an input object are a separate runtime
@@ -309,65 +275,55 @@ export default function KeepTypeGuardsInSyncGuidePage() {
           additional own enumerable string keys. Enable it when the runtime
           boundary requires a closed object shape.
         </Paragraph>
-      </Stack>
+      </GuideSection>
 
-      <Stack variant='section' gap='md'>
-        <Heading variant='h2' className='text-2xl tracking-tight'>
-          Choose the right source of truth
-        </Heading>
-        <div className='overflow-x-auto rounded-md border'>
-          <table className='w-full min-w-2xl border-collapse text-left text-sm'>
-            <thead>
-              <tr className='border-b bg-primary/5'>
-                <th className='px-4 py-3 font-semibold tracking-wide'>
-                  Approach
-                </th>
-                <th className='px-4 py-3 font-semibold tracking-wide'>
-                  Source of truth
-                </th>
-                <th className='px-4 py-3 font-semibold tracking-wide'>
-                  Best for
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr className='border-b'>
-                <td className='px-4 py-3'>Manual predicate</td>
-                <td className='px-4 py-3'>Your implementation</td>
-                <td className='px-4 py-3'>Custom, non-structural logic</td>
-              </tr>
-              <tr className='border-b'>
-                <td className='px-4 py-3'>struct</td>
-                <td className='px-4 py-3'>The guard field map</td>
-                <td className='px-4 py-3'>Guard-first object types</td>
-              </tr>
-              <tr className='border-b'>
-                <td className='px-4 py-3'>typedStruct</td>
-                <td className='px-4 py-3'>An existing TypeScript type</td>
-                <td className='px-4 py-3'>Type-first application code</td>
-              </tr>
-              <tr>
-                <td className='px-4 py-3'>Schema library or codegen</td>
-                <td className='px-4 py-3'>A schema or generated artifact</td>
-                <td className='px-4 py-3'>
-                  Rich errors, transforms, or generation
-                </td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
+      <GuideSection title='Choose the right source of truth'>
+        <GuideTable
+          columns={['Approach', 'Source of truth', 'Best for']}
+          rows={[
+            {
+              key: 'manual-predicate',
+              cells: [
+                'Manual predicate',
+                'Your implementation',
+                'Custom, non-structural logic'
+              ]
+            },
+            {
+              key: 'struct',
+              cells: [
+                'struct',
+                'The guard field map',
+                'Guard-first object types'
+              ]
+            },
+            {
+              key: 'typed-struct',
+              cells: [
+                'typedStruct',
+                'An existing TypeScript type',
+                'Type-first application code'
+              ]
+            },
+            {
+              key: 'schema-library',
+              cells: [
+                'Schema library or codegen',
+                'A schema or generated artifact',
+                'Rich errors, transforms, or generation'
+              ]
+            }
+          ]}
+        />
         <Paragraph>
           Use <code>struct</code> when the guard should define the resulting
           type. Use <code>typedStruct</code> when the TypeScript type already
           exists and the hand-written guard must follow it.
         </Paragraph>
-      </Stack>
+      </GuideSection>
 
-      <Stack variant='section' gap='md'>
-        <Heading variant='h2' className='text-2xl tracking-tight'>
-          What typedStruct does not do
-        </Heading>
-        <ul className='list-disc space-y-2 pl-6'>
+      <GuideSection title='What typedStruct does not do'>
+        <GuideList>
           <li>It does not generate runtime validation from erased types.</li>
           <li>
             It does not track or validate numeric and symbol properties on the
@@ -383,18 +339,15 @@ export default function KeepTypeGuardsInSyncGuidePage() {
             It does not replace a schema-first workflow when a schema is your
             actual source of truth.
           </li>
-        </ul>
+        </GuideList>
         <Paragraph>
           It is intentionally smaller: a typed bridge between an existing object
           type and the guards you choose to run.
         </Paragraph>
-      </Stack>
+      </GuideSection>
 
-      <Stack variant='section' gap='md' className='border-t pt-8'>
-        <Heading variant='h2' className='text-2xl tracking-tight'>
-          Summary
-        </Heading>
-        <ul className='list-disc space-y-2 pl-6'>
+      <GuideSection title='Summary' className='border-t pt-8'>
+        <GuideList>
           <li>
             Use <code>typedStruct&lt;T&gt;()</code> when a string-keyed object
             type <code>T</code> already exists and needs a runtime guard.
@@ -408,7 +361,7 @@ export default function KeepTypeGuardsInSyncGuidePage() {
             Use <code>exact: true</code> only when runtime inputs must reject
             additional keys.
           </li>
-        </ul>
+        </GuideList>
         <Paragraph>
           For the complete contract and additional examples, see the{' '}
           <TextLink href={API_REFERENCE_PATHS.typedStruct}>
@@ -416,7 +369,7 @@ export default function KeepTypeGuardsInSyncGuidePage() {
           </TextLink>
           .
         </Paragraph>
-      </Stack>
-    </Stack>
+      </GuideSection>
+    </GuideArticle>
   );
 }

--- a/docs/app/guides/validate-unknown-without-schema-library/page.tsx
+++ b/docs/app/guides/validate-unknown-without-schema-library/page.tsx
@@ -1,7 +1,13 @@
 import { CodeBlock } from '@/components/code/code-block';
-import { Heading } from '@/components/ui/heading';
+import {
+  GuideArticle,
+  GuideCallout,
+  GuideHeader,
+  GuideList,
+  GuideSection
+} from '@/components/guides/guide-layout';
+import { GuideTable } from '@/components/guides/guide-table';
 import { Paragraph } from '@/components/ui/paragraph';
-import { Stack } from '@/components/ui/stack';
 import { TextLink } from '@/components/ui/text-link';
 import { GUIDE_PATHS } from '@/constants/guides';
 import { API_REFERENCE_PATHS } from '@/lib/api-metadata';
@@ -153,39 +159,14 @@ isMessage({ title: '   ', body: 'Hello' }); // false`;
 
 export default function ValidateUnknownWithoutSchemaLibraryGuidePage() {
   return (
-    <Stack
-      variant='article'
-      className='container mx-auto max-w-4xl px-4 py-10'
-      gap='xl'
-    >
-      <Stack variant='section' gap='sm' className='border-b pb-8'>
-        <nav aria-label='Breadcrumb'>
-          <ol className='flex items-center gap-2 text-sm font-medium tracking-[0.14em] uppercase text-primary/70'>
-            <li>
-              <TextLink href={GUIDE_PATHS.index} className='text-inherit'>
-                Guides
-              </TextLink>
-            </li>
-            <li aria-hidden='true'>/</li>
-            <li aria-current='page'>Validate unknown</li>
-          </ol>
-        </nav>
-        <Heading
-          variant='h1'
-          className='max-w-3xl leading-tight tracking-tight'
-        >
-          How to Validate unknown in TypeScript Without a Schema Library
-        </Heading>
-        <Paragraph variant='lead' className='max-w-3xl text-primary/80'>
-          Keep untrusted values unknown, compose the runtime checks you need,
-          and narrow them with a small tagged result.
-        </Paragraph>
-      </Stack>
+    <GuideArticle>
+      <GuideHeader
+        breadcrumbLabel='Validate unknown'
+        title='How to Validate unknown in TypeScript Without a Schema Library'
+        description='Keep untrusted values unknown, compose the runtime checks you need, and narrow them with a small tagged result.'
+      />
 
-      <Stack variant='section' gap='md'>
-        <Heading variant='h2' className='text-2xl tracking-tight'>
-          The quick answer
-        </Heading>
+      <GuideSection title='The quick answer'>
         <Paragraph>
           Build a reusable object guard, then pass it and the unknown value to{' '}
           <code>safeParse</code>.
@@ -201,12 +182,9 @@ export default function ValidateUnknownWithoutSchemaLibraryGuidePage() {
           There is no generated schema and no hidden conversion. The accepted
           type is inferred directly from the guards you composed.
         </Paragraph>
-      </Stack>
+      </GuideSection>
 
-      <Stack variant='section' gap='md'>
-        <Heading variant='h2' className='text-2xl tracking-tight'>
-          Keep boundary values unknown
-        </Heading>
+      <GuideSection title='Keep boundary values unknown'>
         <Paragraph>
           HTTP responses, parsed JSON, storage values, message payloads, and
           data from third-party code do not become trustworthy because your
@@ -217,16 +195,13 @@ export default function ValidateUnknownWithoutSchemaLibraryGuidePage() {
           it prevents property access until code has established what the value
           actually is.
         </Paragraph>
-        <blockquote className='border-l-2 border-primary/70 py-1 pl-5 text-lg leading-relaxed'>
+        <GuideCallout>
           <code>unknown</code> is not missing type information. It is an honest
           description of an unverified boundary value.
-        </blockquote>
-      </Stack>
+        </GuideCallout>
+      </GuideSection>
 
-      <Stack variant='section' gap='md'>
-        <Heading variant='h2' className='text-2xl tracking-tight'>
-          A type assertion is not validation
-        </Heading>
+      <GuideSection title='A type assertion is not validation'>
         <Paragraph>
           The shortest way past <code>unknown</code> is often an <code>as</code>{' '}
           assertion. It is also the easiest way to move the risk somewhere less
@@ -241,12 +216,9 @@ export default function ValidateUnknownWithoutSchemaLibraryGuidePage() {
           A guard connects both sides: it returns a boolean at runtime and
           narrows the same value when that boolean is true.
         </Paragraph>
-      </Stack>
+      </GuideSection>
 
-      <Stack variant='section' gap='md'>
-        <Heading variant='h2' className='text-2xl tracking-tight'>
-          Compose the payload you actually accept
-        </Heading>
+      <GuideSection title='Compose the payload you actually accept'>
         <Paragraph>
           Start with primitive guards, then compose literals, optional keys,
           nullable values, arrays, and nested objects.
@@ -261,12 +233,9 @@ export default function ValidateUnknownWithoutSchemaLibraryGuidePage() {
           <code>nullable</code> means an existing value may be <code>null</code>
           . Keeping those meanings separate makes the runtime contract explicit.
         </Paragraph>
-      </Stack>
+      </GuideSection>
 
-      <Stack variant='section' gap='md'>
-        <Heading variant='h2' className='text-2xl tracking-tight'>
-          Use a direct guard or a tagged result
-        </Heading>
+      <GuideSection title='Use a direct guard or a tagged result'>
         <Paragraph>
           Guards already work directly in TypeScript control flow. Use{' '}
           <code>safeParse</code> when the validated value needs to move through
@@ -277,12 +246,9 @@ export default function ValidateUnknownWithoutSchemaLibraryGuidePage() {
           <code>safeParse</code> does not clone or transform the value. On
           success, it returns the same value after the guard has accepted it.
         </Paragraph>
-      </Stack>
+      </GuideSection>
 
-      <Stack variant='section' gap='md'>
-        <Heading variant='h2' className='text-2xl tracking-tight'>
-          Validate JSON at the decode boundary
-        </Heading>
+      <GuideSection title='Validate JSON at the decode boundary'>
         <Paragraph>
           <code>JSON.parse</code> returns <code>any</code>.{' '}
           <code>safeJsonParse</code> contains that unsafe result as{' '}
@@ -294,12 +260,9 @@ export default function ValidateUnknownWithoutSchemaLibraryGuidePage() {
           share the same small failure result, and values are never coerced to
           satisfy the guard.
         </Paragraph>
-      </Stack>
+      </GuideSection>
 
-      <Stack variant='section' gap='md'>
-        <Heading variant='h2' className='text-2xl tracking-tight'>
-          Decide whether extra keys are allowed
-        </Heading>
+      <GuideSection title='Decide whether extra keys are allowed'>
         <Paragraph>
           By default, <code>struct</code> validates declared fields and permits
           additional keys. Use <code>exact: true</code> when the boundary needs
@@ -311,12 +274,9 @@ export default function ValidateUnknownWithoutSchemaLibraryGuidePage() {
           <code>Object.keys</code> semantics, so symbol properties are outside
           this check.
         </Paragraph>
-      </Stack>
+      </GuideSection>
 
-      <Stack variant='section' gap='md'>
-        <Heading variant='h2' className='text-2xl tracking-tight'>
-          Add focused domain rules
-        </Heading>
+      <GuideSection title='Add focused domain rules'>
         <Paragraph>
           Structural checks are often enough. When a field has a small business
           rule, compose a refinement after its broader guard.
@@ -327,60 +287,47 @@ export default function ValidateUnknownWithoutSchemaLibraryGuidePage() {
           rather than <code>unknown</code>. The resulting guard stays reusable
           and preserves normal TypeScript narrowing.
         </Paragraph>
-      </Stack>
+      </GuideSection>
 
-      <Stack variant='section' gap='md'>
-        <Heading variant='h2' className='text-2xl tracking-tight'>
-          Choose the smallest sufficient approach
-        </Heading>
-        <div className='overflow-x-auto rounded-md border'>
-          <table className='w-full min-w-2xl border-collapse text-left text-sm'>
-            <thead>
-              <tr className='border-b bg-primary/5'>
-                <th className='px-4 py-3 font-semibold tracking-wide'>
-                  Approach
-                </th>
-                <th className='px-4 py-3 font-semibold tracking-wide'>
-                  Best for
-                </th>
-                <th className='px-4 py-3 font-semibold tracking-wide'>
-                  Tradeoff
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr className='border-b'>
-                <td className='px-4 py-3'>Inline typeof checks</td>
-                <td className='px-4 py-3'>One local primitive value</td>
-                <td className='px-4 py-3'>Repeats as shapes grow</td>
-              </tr>
-              <tr className='border-b'>
-                <td className='px-4 py-3'>is-kit guards</td>
-                <td className='px-4 py-3'>Reusable boolean validation</td>
-                <td className='px-4 py-3'>No structured error details</td>
-              </tr>
-              <tr>
-                <td className='px-4 py-3'>Schema library</td>
-                <td className='px-4 py-3'>Rich errors and transformations</td>
-                <td className='px-4 py-3'>
-                  Introduces a schema-first workflow
-                </td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
+      <GuideSection title='Choose the smallest sufficient approach'>
+        <GuideTable
+          columns={['Approach', 'Best for', 'Tradeoff']}
+          rows={[
+            {
+              key: 'inline-typeof',
+              cells: [
+                'Inline typeof checks',
+                'One local primitive value',
+                'Repeats as shapes grow'
+              ]
+            },
+            {
+              key: 'is-kit-guards',
+              cells: [
+                'is-kit guards',
+                'Reusable boolean validation',
+                'No structured error details'
+              ]
+            },
+            {
+              key: 'schema-library',
+              cells: [
+                'Schema library',
+                'Rich errors and transformations',
+                'Introduces a schema-first workflow'
+              ]
+            }
+          ]}
+        />
         <Paragraph>
           You are still adding is-kit as a package. The distinction is that it
           is a zero-runtime-dependency type guard toolkit, not a schema language
           or validation framework.
         </Paragraph>
-      </Stack>
+      </GuideSection>
 
-      <Stack variant='section' gap='md'>
-        <Heading variant='h2' className='text-2xl tracking-tight'>
-          When a schema library is the better choice
-        </Heading>
-        <ul className='list-disc space-y-2 pl-6'>
+      <GuideSection title='When a schema library is the better choice'>
+        <GuideList>
           <li>
             You need field paths and multiple structured validation issues.
           </li>
@@ -389,18 +336,15 @@ export default function ValidateUnknownWithoutSchemaLibraryGuidePage() {
           <li>
             Your forms or API framework integrate with a schema ecosystem.
           </li>
-        </ul>
+        </GuideList>
         <Paragraph>
           is-kit guards answer a narrower question: does this value satisfy the
           predicate, and if so, what can TypeScript safely narrow it to?
         </Paragraph>
-      </Stack>
+      </GuideSection>
 
-      <Stack variant='section' gap='md' className='border-t pt-8'>
-        <Heading variant='h2' className='text-2xl tracking-tight'>
-          Summary
-        </Heading>
-        <ul className='list-disc space-y-2 pl-6'>
+      <GuideSection title='Summary' className='border-t pt-8'>
+        <GuideList>
           <li>Keep unverified boundary values typed as unknown.</li>
           <li>Use guards instead of assertions when runtime trust matters.</li>
           <li>Compose small predicates into the payload shape you accept.</li>
@@ -411,14 +355,14 @@ export default function ValidateUnknownWithoutSchemaLibraryGuidePage() {
           <li>
             Adopt a schema library when richer validation is the requirement.
           </li>
-        </ul>
+        </GuideList>
         <Paragraph>
           Continue with the{' '}
           <TextLink href={API_REFERENCE_PATHS.parse}>parse</TextLink> and{' '}
           <TextLink href={API_REFERENCE_PATHS.struct}>struct</TextLink> API
           references for the complete contracts.
         </Paragraph>
-      </Stack>
-    </Stack>
+      </GuideSection>
+    </GuideArticle>
   );
 }

--- a/docs/components/guides/guide-layout.tsx
+++ b/docs/components/guides/guide-layout.tsx
@@ -1,0 +1,138 @@
+import type * as React from 'react';
+
+import { Heading } from '@/components/ui/heading';
+import { Paragraph } from '@/components/ui/paragraph';
+import { Stack } from '@/components/ui/stack';
+import { TextLink } from '@/components/ui/text-link';
+import { GUIDE_PATHS } from '@/constants/guides';
+import { cn } from '@/lib/utils';
+
+type GuideArticleProps = React.ComponentPropsWithoutRef<'article'>;
+
+/**
+ * Provides the shared width and vertical rhythm for a guide article.
+ * @param props Standard article attributes and guide content.
+ * @returns Guide article container.
+ */
+export function GuideArticle({ className, ...props }: GuideArticleProps) {
+  return (
+    <Stack
+      variant='article'
+      className={cn('container mx-auto max-w-4xl px-4 py-10', className)}
+      gap='xl'
+      {...props}
+    />
+  );
+}
+
+type GuideHeaderProps = {
+  /** Short current-page label shown after the Guides breadcrumb. */
+  breadcrumbLabel: string;
+  /** Main guide heading. */
+  title: string;
+  /** Introductory summary shown below the heading. */
+  description: React.ReactNode;
+};
+
+/**
+ * Renders a guide breadcrumb, title, and lead description.
+ * @param breadcrumbLabel Current guide label used in the breadcrumb.
+ * @param title Guide page title.
+ * @param description Short guide introduction.
+ * @returns Shared guide header.
+ */
+export function GuideHeader({
+  breadcrumbLabel,
+  title,
+  description
+}: GuideHeaderProps) {
+  return (
+    <Stack variant='section' gap='sm' className='border-b pb-8'>
+      <nav aria-label='Breadcrumb'>
+        <ol className='flex items-center gap-2 text-sm font-medium tracking-[0.14em] uppercase text-primary/70'>
+          <li>
+            <TextLink href={GUIDE_PATHS.index} className='text-inherit'>
+              Guides
+            </TextLink>
+          </li>
+          <li aria-hidden='true'>/</li>
+          <li aria-current='page'>{breadcrumbLabel}</li>
+        </ol>
+      </nav>
+      <Heading variant='h1' className='max-w-3xl leading-tight tracking-tight'>
+        {title}
+      </Heading>
+      <Paragraph variant='lead' className='max-w-3xl text-primary/80'>
+        {description}
+      </Paragraph>
+    </Stack>
+  );
+}
+
+type GuideSectionProps = React.ComponentPropsWithoutRef<'section'> & {
+  /** Section heading rendered before the content. */
+  title: string;
+};
+
+/**
+ * Renders a consistently spaced guide section with an h2 heading.
+ * @param title Section heading.
+ * @param props Standard section attributes and section content.
+ * @returns Guide content section.
+ */
+export function GuideSection({
+  className,
+  title,
+  children,
+  ...props
+}: GuideSectionProps) {
+  return (
+    <Stack variant='section' gap='md' className={className} {...props}>
+      <Heading variant='h2' className='text-2xl tracking-tight'>
+        {title}
+      </Heading>
+      {children}
+    </Stack>
+  );
+}
+
+type GuideCalloutProps = React.ComponentPropsWithoutRef<'blockquote'> & {
+  /** Applies stronger emphasis for key takeaways. */
+  emphasized?: boolean;
+};
+
+/**
+ * Highlights a guide note or takeaway with the shared quote treatment.
+ * @param emphasized Whether to render the callout with stronger text.
+ * @param props Standard blockquote attributes and callout content.
+ * @returns Styled guide callout.
+ */
+export function GuideCallout({
+  className,
+  emphasized = false,
+  ...props
+}: GuideCalloutProps) {
+  return (
+    <blockquote
+      className={cn(
+        'border-l-2 border-primary/70 py-1 pl-5 text-lg leading-relaxed',
+        emphasized && 'font-semibold',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+type GuideListProps = React.ComponentPropsWithoutRef<'ul'>;
+
+/**
+ * Renders the shared unordered-list style used in guide summaries and notes.
+ * @param props Standard unordered-list attributes and list items.
+ * @returns Styled guide list.
+ */
+export function GuideList({ className, ...props }: GuideListProps) {
+  return (
+    <ul className={cn('list-disc space-y-2 pl-6', className)} {...props} />
+  );
+}

--- a/docs/components/guides/guide-table.tsx
+++ b/docs/components/guides/guide-table.tsx
@@ -1,0 +1,53 @@
+import type * as React from 'react';
+
+type GuideTableRow = {
+  /** Stable key used when rendering the row. */
+  key: string;
+  /** Cells ordered to match the table columns. */
+  cells: readonly React.ReactNode[];
+};
+
+type GuideTableProps = {
+  /** Column headings displayed across the table header. */
+  columns: readonly string[];
+  /** Body rows displayed in column order. */
+  rows: readonly GuideTableRow[];
+};
+
+/**
+ * Renders a responsive comparison table shared by guide pages.
+ * @param columns Column headings.
+ * @param rows Table rows with stable keys and ordered cells.
+ * @returns Responsive guide table.
+ */
+export function GuideTable({ columns, rows }: GuideTableProps) {
+  return (
+    <div className='overflow-x-auto rounded-md border'>
+      <table className='w-full min-w-2xl border-collapse text-left text-sm'>
+        <thead>
+          <tr className='border-b bg-primary/5'>
+            {columns.map((column) => (
+              <th
+                key={column}
+                className='px-4 py-3 font-semibold tracking-wide'
+              >
+                {column}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row) => (
+            <tr key={row.key} className='border-b last:border-b-0'>
+              {row.cells.map((cell, index) => (
+                <td key={`${row.key}-${columns[index]}`} className='px-4 py-3'>
+                  {cell}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Extract shared guide components.

<!-- A brief summary of the changes -->

## Description

- extract shared guide article, header, section, callout, and list components
- add a reusable responsive table component for guide comparisons

<!-- A detailed explanation of the changes, including why they are needed -->
