### PR TITLE
test: add TypeScript compatibility matrix

### DIFF
--- a/.github/workflows/test-types.yaml
+++ b/.github/workflows/test-types.yaml
@@ -17,3 +17,25 @@ jobs:
         run: mise run build
       - name: Run type tests
         run: mise run test-types
+
+  compatibility:
+    name: TypeScript ${{ matrix.typescript }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        typescript:
+          - '5.7'
+          - '5.8'
+          - '5.9'
+          - '6.0'
+          - '7.0'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+      - name: Setup project
+        uses: ./.github/actions/setup-project
+      - name: Build package
+        run: mise run build
+      - name: Test published declarations
+        run: pnpm test:typescript-compat ${{ matrix.typescript }}

--- a/README.md
+++ b/README.md
@@ -79,6 +79,14 @@ vlt install is-kit
 ```
 
 ESM and CJS builds are available for npm consumers, and bundled types are included.
+The published declarations support TypeScript 5.7 and newer. CI compiles the
+packed package against every TypeScript minor from 5.7 through the current
+stable release.
+
+TypeScript 7 can type-check is-kit declarations, but TypeScript 7.0 does not
+ship the legacy JavaScript Compiler API. Tools that need that API can follow
+the official [TypeScript 7 side-by-side guidance](https://devblogs.microsoft.com/typescript/announcing-typescript-7-0/#running-side-by-side-with-typescript-6-0)
+and use `@typescript/typescript6` for programmatic access.
 
 vlt requires registry configuration before installing a package by name. Run
 `vlt setup` once if a registry has not been configured yet.

--- a/docs/app/guides/typescript-compiler-api/page.tsx
+++ b/docs/app/guides/typescript-compiler-api/page.tsx
@@ -55,6 +55,27 @@ const declarations = nodes.filter(isNamedDeclaration);
 // (ts.ClassDeclaration | ts.FunctionDeclaration |
 //  ts.VariableDeclaration)[]`;
 
+const reusableContexts = `import * as ts from 'typescript';
+import { and, refineKey } from 'is-kit';
+
+const isIdentifierNamedJsxAttribute = and(
+  ts.isJsxAttribute,
+  refineKey('name', ts.isIdentifier),
+);
+
+declare const attributes: readonly ts.JsxAttributeLike[];
+
+const attribute = attributes.find(isIdentifierNamedJsxAttribute);
+// (ts.JsxAttribute & { name: ts.Identifier }) | undefined
+
+function visit(node: ts.Node): void {
+  if (isIdentifierNamedJsxAttribute(node)) {
+    node.name.text;
+  }
+
+  ts.forEachChild(node, visit);
+}`;
+
 const optionalChild = `import * as ts from 'typescript';
 import { refineDefinedKey } from 'is-kit';
 
@@ -164,6 +185,19 @@ export default function TypeScriptCompilerApiGuidePage() {
           The resulting functions remain ordinary type predicates. Reuse them in
           branches, visitors, <code>filter</code>, <code>find</code>, or other
           APIs that understand TypeScript predicates.
+        </Paragraph>
+      </GuideSection>
+
+      <GuideSection title='Reuse a refined node in find and visitors'>
+        <Paragraph>
+          A named guard can move between collection methods and AST traversal
+          without losing its refined child type. This is especially useful for
+          repeated JSX attribute checks.
+        </Paragraph>
+        <CodeBlock code={reusableContexts} language='ts' />
+        <Paragraph>
+          The same predicate narrows the result returned by <code>find</code>{' '}
+          and the current node inside the visitor branch.
         </Paragraph>
       </GuideSection>
 
@@ -280,6 +314,24 @@ export default function TypeScriptCompilerApiGuidePage() {
           <li>It does not detect cycles or control AST traversal.</li>
           <li>It does not replace a clear one-off inline condition.</li>
         </GuideList>
+      </GuideSection>
+
+      <GuideSection title='TypeScript 7 Compiler API compatibility'>
+        <Paragraph>
+          TypeScript 7 can type-check is-kit declarations, but TypeScript 7.0
+          does not ship the legacy JavaScript Compiler API used by the examples
+          in this guide. API-based tooling should keep the TypeScript 6 API
+          available through the official{' '}
+          <TextLink href='https://www.npmjs.com/package/@typescript/typescript6'>
+            @typescript/typescript6 compatibility package
+          </TextLink>
+          .
+        </Paragraph>
+        <Paragraph>
+          This is a TypeScript 7 platform transition rather than an is-kit
+          runtime limitation. is-kit itself has no TypeScript runtime or peer
+          dependency.
+        </Paragraph>
       </GuideSection>
 
       <GuideSection title='Summary' className='border-t pt-8'>

--- a/mise.toml
+++ b/mise.toml
@@ -33,6 +33,10 @@ run = "pnpm test"
 description = "Run tsd type tests"
 run = "pnpm test:types"
 
+[tasks.test-typescript-compat]
+description = "Compile the packed declarations with one TypeScript version"
+run = "pnpm test:typescript-compat"
+
 [tasks.test-package]
 description = "Smoke-test the packed npm artifact"
 run = "pnpm test:package"

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "scripts": {
     "test": "jest",
     "test:types": "tsd && tsc -p tests-d/tsconfig.property-refinement.json",
+    "test:typescript-compat": "node tests/typescript-compatibility.mjs",
     "test:package": "node tests/package-smoke.mjs",
     "test:package:vlt": "node tests/vlt-package-smoke.mjs",
     "lint": "oxlint .",

--- a/tests/typescript-compatibility.mjs
+++ b/tests/typescript-compatibility.mjs
@@ -1,0 +1,111 @@
+import { execFileSync } from 'node:child_process';
+import {
+  copyFileSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const typescriptVersionSpec = process.argv[2];
+
+if (
+  !typescriptVersionSpec ||
+  !/^\d+\.\d+(?:\.\d+)?$/.test(typescriptVersionSpec)
+) {
+  throw new Error(
+    'Pass a TypeScript minor or exact version, for example: pnpm test:typescript-compat 5.7'
+  );
+}
+
+const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const typescriptMajor = Number.parseInt(
+  typescriptVersionSpec.split('.')[0],
+  10
+);
+// WHY: TypeScript 7.0 ships a native type checker without the legacy
+// JavaScript Compiler API. Its official compatibility package keeps API-based
+// tools on the TypeScript 6 surface while the TypeScript 7 checker runs.
+const compilerApiPackage =
+  typescriptMajor >= 7
+    ? '@typescript/typescript6@6.0'
+    : `typescript@${typescriptVersionSpec}`;
+const fixtureDirectory = join(
+  repositoryRoot,
+  'tests',
+  'typescript-compatibility'
+);
+const temporaryRoot = mkdtempSync(
+  join(tmpdir(), `is-kit-typescript-${typescriptVersionSpec}-`)
+);
+const packageDirectory = join(temporaryRoot, 'package');
+const consumerDirectory = join(temporaryRoot, 'consumer');
+const npmCacheDirectory = join(temporaryRoot, 'npm-cache');
+const npmEnvironment = {
+  ...process.env,
+  npm_config_cache: npmCacheDirectory,
+  npm_config_update_notifier: 'false'
+};
+
+const run = (command, args, cwd = consumerDirectory) =>
+  execFileSync(command, args, {
+    cwd,
+    env: npmEnvironment,
+    stdio: 'inherit'
+  });
+
+try {
+  mkdirSync(packageDirectory, { recursive: true });
+  mkdirSync(consumerDirectory, { recursive: true });
+
+  run('npm', ['pack', '--pack-destination', packageDirectory], repositoryRoot);
+  const [filename] = readdirSync(packageDirectory).filter((name) =>
+    name.endsWith('.tgz')
+  );
+  if (!filename) throw new Error('npm pack did not create a tarball');
+
+  copyFileSync(
+    join(fixtureDirectory, 'consumer.ts'),
+    join(consumerDirectory, 'consumer.ts')
+  );
+  copyFileSync(
+    join(fixtureDirectory, 'tsconfig.json'),
+    join(consumerDirectory, 'tsconfig.json')
+  );
+
+  run('npm', [
+    'install',
+    '--ignore-scripts',
+    '--no-audit',
+    '--no-fund',
+    '--package-lock=false',
+    join(packageDirectory, filename),
+    `typescript@${typescriptVersionSpec}`,
+    `typescript-api@npm:${compilerApiPackage}`
+  ]);
+
+  const installedTypescriptVersion = JSON.parse(
+    readFileSync(
+      join(consumerDirectory, 'node_modules', 'typescript', 'package.json'),
+      'utf8'
+    )
+  ).version;
+
+  run(process.execPath, [
+    join(consumerDirectory, 'node_modules', 'typescript', 'bin', 'tsc'),
+    '--project',
+    'tsconfig.json',
+    '--pretty',
+    'false'
+  ]);
+
+  console.log(
+    `Published declarations passed with TypeScript ${installedTypescriptVersion} (requested ${typescriptVersionSpec}).`
+  );
+} finally {
+  rmSync(temporaryRoot, { recursive: true, force: true });
+}

--- a/tests/typescript-compatibility/consumer.ts
+++ b/tests/typescript-compatibility/consumer.ts
@@ -1,0 +1,109 @@
+import * as ts from 'typescript-api';
+import { and, oneOf, refineDefinedKey, refineIndex, refineKey } from 'is-kit';
+
+// =============================================
+// describe: published declaration compatibility
+// =============================================
+// Note: This fixture compiles against the packed package and the selected
+// TypeScript version, not against source aliases or the workspace compiler.
+
+// it: composes Compiler API refinements over a known input domain
+const isCallWithIdentifierExpression = and(
+  ts.isCallExpression,
+  refineKey('expression', ts.isIdentifier)
+);
+declare const node: ts.Node;
+
+if (isCallWithIdentifierExpression(node)) {
+  const expression: ts.Identifier = node.expression;
+  void expression;
+}
+
+// it: preserves a union produced by same-domain refinements
+const isStringLike = oneOf(
+  ts.isStringLiteral,
+  ts.isNoSubstitutionTemplateLiteral
+);
+declare const nodes: readonly ts.Node[];
+const strings = nodes.filter(isStringLike);
+const stringLikeNodes: Array<
+  ts.StringLiteral | ts.NoSubstitutionTemplateLiteral
+> = strings;
+void stringLikeNodes;
+
+// it: reuses a child refinement in find and a visitor branch
+const isIdentifierNamedJsxAttribute = and(
+  ts.isJsxAttribute,
+  refineKey('name', ts.isIdentifier)
+);
+declare const attributes: readonly ts.JsxAttributeLike[];
+const attribute = attributes.find(isIdentifierNamedJsxAttribute);
+
+if (attribute) {
+  const name: ts.Identifier = attribute.name;
+  void name;
+}
+
+function visit(current: ts.Node): void {
+  if (isIdentifierNamedJsxAttribute(current)) {
+    const name: ts.Identifier = current.name;
+    void name;
+  }
+
+  ts.forEachChild(current, visit);
+}
+
+void visit;
+
+// it: requires and refines an optional Compiler API child
+const hasCallInitializer = refineDefinedKey('initializer', ts.isCallExpression);
+declare const declaration: ts.VariableDeclaration;
+
+if (hasCallInitializer(declaration)) {
+  const initializer: ts.CallExpression = declaration.initializer;
+  void initializer;
+}
+
+// it: composes optional, required, and indexed child refinements
+const isBlockStartingWithReturn = and(
+  ts.isBlock,
+  refineKey('statements', refineIndex(0, ts.isReturnStatement))
+);
+const hasBodyStartingWithReturn = refineDefinedKey(
+  'body',
+  isBlockStartingWithReturn
+);
+declare const method: ts.MethodDeclaration;
+
+if (hasBodyStartingWithReturn(method)) {
+  const statement: ts.ReturnStatement = method.body.statements[0];
+  void statement;
+}
+
+// it: rejects keys that may identify multiple runtime locations
+declare const broadKey: string;
+declare const unionKey: 'expression' | 'arguments';
+declare const patternedKey: `child-${string}`;
+declare const brandedNumberKey: number & { readonly brand: 'property-key' };
+
+// @ts-expect-error: A broad string does not identify one property.
+refineKey(broadKey, ts.isIdentifier);
+// @ts-expect-error: A key union does not identify one property.
+refineKey(unionKey, ts.isIdentifier);
+// @ts-expect-error: A template-literal pattern does not identify one property.
+refineDefinedKey(patternedKey, ts.isIdentifier);
+// @ts-expect-error: A branded number may identify multiple properties.
+refineKey(brandedNumberKey, ts.isIdentifier);
+
+// it: rejects indices that do not identify one array element
+declare const dynamicIndex: number;
+declare const unionIndex: 0 | 1;
+
+// @ts-expect-error: A dynamic number does not identify one array element.
+refineIndex(dynamicIndex, ts.isIdentifier);
+// @ts-expect-error: An index union does not identify one array element.
+refineIndex(unionIndex, ts.isIdentifier);
+// @ts-expect-error: Negative numbers are not array indices.
+refineIndex(-1, ts.isIdentifier);
+// @ts-expect-error: Fractional numbers are not array indices.
+refineIndex(0.5, ts.isIdentifier);

--- a/tests/typescript-compatibility/tsconfig.json
+++ b/tests/typescript-compatibility/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "exactOptionalPropertyTypes": true,
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "noEmit": true,
+    "noUncheckedIndexedAccess": true,
+    "strict": true,
+    "target": "ES2022",
+    "types": []
+  },
+  "files": ["consumer.ts"]
+}


### PR DESCRIPTION
## Summary

Add TypeScript compatibility matrix.

<!-- A brief summary of the changes -->

## Description

- add packed-package compatibility tests for `TypeScript` 5.7 through 7.0
- verify Compiler API composition and singleton-key rejection across supported versions
- document `TypeScript` 5.7 as the minimum supported version
- document the `TypeScript` 7 Compiler API compatibility-package requirement

<!-- A detailed explanation of the changes, including why they are needed -->
