### PR TITLE
fix: prevent key helpers from over-narrowing union key

### DIFF
--- a/README.md
+++ b/README.md
@@ -520,6 +520,11 @@ if (isAdmin(value)) {
 }
 ```
 
+Singleton literal keys preserve key-specific narrowing. Union, broad, patterned,
+or branded key domains remain usable as runtime checks, but they narrow only to
+an object—or to the base guard type for `narrowKeyTo`—because one runtime key
+cannot prove that every possible key was checked.
+
 ## 🌍 Real-world use cases
 
 Here are the kinds of problems `is-kit` is especially good at solving:

--- a/docs/app/api-reference/equals/page.tsx
+++ b/docs/app/api-reference/equals/page.tsx
@@ -58,6 +58,8 @@ export default function EqualsPage() {
           <Heading variant='h2'>equalsBy / equalsKey</Heading>
           <Paragraph>
             Compare by derived values or by property keys when building guards.
+            <code>equalsKey</code> narrows a singleton literal property; union
+            and broad keys remain runtime checks with object-only narrowing.
           </Paragraph>
         </Stack>
         <CodeBlock language='ts' code={sampleEqualsByAndKey} />

--- a/docs/app/api-reference/key/page.tsx
+++ b/docs/app/api-reference/key/page.tsx
@@ -111,7 +111,9 @@ export default function KeyPage() {
           <Heading variant='h2'>hasKey</Heading>
           <Paragraph>
             Narrow an unknown value to an object that owns a specific key. Handy
-            before custom refinements or discriminated-union checks.
+            before custom refinements or discriminated-union checks. A singleton
+            literal key narrows that property; a multi-value key domain narrows
+            only to <code>object</code>.
           </Paragraph>
         </Stack>
         <CodeBlock language='ts' code={sampleHasKey} />
@@ -122,7 +124,8 @@ export default function KeyPage() {
           <Paragraph>
             Narrow an unknown value to an object that owns all specified keys.
             Useful as a compact pre-check before discriminated-union
-            refinements.
+            refinements. Key-specific narrowing requires every argument to be a
+            singleton literal key.
           </Paragraph>
         </Stack>
         <CodeBlock language='ts' code={sampleHasKeys} />
@@ -132,7 +135,8 @@ export default function KeyPage() {
           <Heading variant='h2'>narrowKeyTo</Heading>
           <Paragraph>
             Build reusable guards that narrow a property to specific literal
-            values.
+            values. A union or broad key remains callable as a runtime check but
+            preserves only the base guard type.
           </Paragraph>
         </Stack>
         <CodeBlock language='ts' code={sampleNarrowKeyTo} />
@@ -174,12 +178,17 @@ export default function KeyPage() {
         <CodeBlock language='ts' code={sampleRefineIndex} />
       </Stack>
       <Stack variant='section' gap='sm'>
-        <Heading variant='h2'>One checked location</Heading>
+        <Heading variant='h2'>Key-specific narrowing</Heading>
         <Paragraph>
-          Property keys and indices must identify one concrete runtime location.
-          Broad keys, unions, template-literal patterns, and branded multi-value
-          key domains are rejected so one lookup cannot claim that several
-          properties were checked.
+          Precise property narrowing requires each key argument to identify one
+          concrete runtime location. The presence and equality helpers keep
+          broad keys, unions, template-literal patterns, and branded multi-value
+          domains usable, but safely omit key-specific narrowing.
+        </Paragraph>
+        <Paragraph>
+          The <code>refine*</code> helpers reject those multi-value domains
+          because their known-input contract must carry one checked child value
+          back onto one concrete location of the parent type.
         </Paragraph>
         <Paragraph>
           For nested Compiler API examples, continue with{' '}

--- a/src/core/equals.ts
+++ b/src/core/equals.ts
@@ -1,7 +1,14 @@
 import type { GuardedOf, Predicate } from '@/types';
 import { hasOwnPropertyKey } from '@/utils/own-properties';
 import { define } from './define';
+import type { SinglePropertyKey } from './key-internals';
 import { isObject } from './object';
+
+type EqualsKeyPredicate<K extends PropertyKey, T> = [
+  SinglePropertyKey<K>
+] extends [never]
+  ? Predicate<object>
+  : <A extends Record<K, unknown>>(input: unknown) => input is A & Record<K, T>;
 
 // WHY: Control-flow analysis does not preserve the narrowed target of a generic
 // predicate like `F extends Predicate<unknown>` at the call site. Re-expressing
@@ -61,23 +68,24 @@ export function equalsBy<F extends Predicate<unknown>, K>(
 /**
  * Creates a guard that matches objects having a key equal to the target value.
  *
- * @param key Property key to compare.
+ * @param key Property key to compare; singleton literals narrow that property.
  * @param target Value to compare using `Object.is`.
- * @returns Predicate narrowing to objects where `key` exists and equals `target`.
+ * @returns Predicate with key-specific narrowing for a singleton literal key,
+ * or object-only narrowing for a multi-value key domain.
  */
-export function equalsKey<K extends PropertyKey, const T>(
+export function equalsKey<const K extends PropertyKey, const T>(
   key: K,
   target: T
-): <A extends Record<K, unknown>>(input: unknown) => input is A & Record<K, T> {
-  const hasMatchingKey = define<Record<K, T>>((input) => {
+): EqualsKeyPredicate<K, T>;
+export function equalsKey(
+  key: PropertyKey,
+  target: unknown
+): Predicate<object> {
+  return define<object>((input) => {
     return (
       isObject(input) &&
       hasOwnPropertyKey(input, key) &&
       Object.is(input[key], target)
     );
   });
-
-  return <A extends Record<K, unknown>>(
-    input: unknown
-  ): input is A & Record<K, T> => hasMatchingKey(input);
 }

--- a/src/core/key-internals.ts
+++ b/src/core/key-internals.ts
@@ -29,11 +29,12 @@ export type KeyPresence<Key extends PropertyKey> = [
   : Record<Key, unknown>;
 
 /** Narrows concrete key arguments, or only object-ness when any may vary. */
-export type KeyPresences<Keys extends readonly PropertyKey[]> = [Keys] extends [
-  SinglePropertyKeys<Keys>
-]
-  ? Record<Keys[number], unknown>
-  : object;
+export type KeyPresences<Keys extends readonly PropertyKey[]> =
+  true extends IsUnion<Keys>
+    ? object
+    : [Keys] extends [SinglePropertyKeys<Keys>]
+      ? Record<Keys[number], unknown>
+      : object;
 
 /** Keeps only one non-negative integer literal that identifies an array index. */
 export type ArrayIndex<Index extends number> =

--- a/src/core/key-internals.ts
+++ b/src/core/key-internals.ts
@@ -1,0 +1,46 @@
+/** Detects whether a type represents more than one possible value. */
+type IsUnion<Value, Whole = Value> = Value extends Whole
+  ? [Whole] extends [Value]
+    ? false
+    : true
+  : never;
+
+/** Keeps only one literal property key so one lookup cannot narrow other keys. */
+export type SinglePropertyKey<Key extends PropertyKey> = [Key] extends [never]
+  ? never
+  : true extends IsUnion<Key>
+    ? never
+    : // WHY: Broad, patterned, and opaque key domains produce index
+      // signatures, which an object with no declared properties satisfies.
+      {} extends Record<Key, never>
+      ? never
+      : Key;
+
+/** Applies the singleton-key constraint to every member of a key tuple. */
+export type SinglePropertyKeys<Keys extends readonly PropertyKey[]> = {
+  [Index in keyof Keys]: Keys[Index] & SinglePropertyKey<Keys[Index]>;
+};
+
+/** Narrows one concrete key, or only object-ness for a multi-value key domain. */
+export type KeyPresence<Key extends PropertyKey> = [
+  SinglePropertyKey<Key>
+] extends [never]
+  ? object
+  : Record<Key, unknown>;
+
+/** Narrows concrete key arguments, or only object-ness when any may vary. */
+export type KeyPresences<Keys extends readonly PropertyKey[]> = [Keys] extends [
+  SinglePropertyKeys<Keys>
+]
+  ? Record<Keys[number], unknown>
+  : object;
+
+/** Keeps only one non-negative integer literal that identifies an array index. */
+export type ArrayIndex<Index extends number> =
+  SinglePropertyKey<Index> extends never
+    ? never
+    : `${Index}` extends `-${string}`
+      ? never
+      : `${Index}` extends `${bigint}`
+        ? Index
+        : never;

--- a/src/core/key.ts
+++ b/src/core/key.ts
@@ -1,68 +1,58 @@
-import type { Guard, GuardedOf, Predicate, Refinement } from '@/types';
+import type { Guard, Predicate, Refinement } from '@/types';
 import { hasOwnPropertyKey, hasOwnPropertyKeys } from '@/utils/own-properties';
 import { equalsKey } from './equals';
 import { define } from './define';
+import type {
+  ArrayIndex,
+  KeyPresence,
+  KeyPresences,
+  SinglePropertyKey
+} from './key-internals';
 import { isObject } from './object';
+
+type NarrowKeyPredicate<A, K extends PropertyKey, T> = [
+  SinglePropertyKey<K>
+] extends [never]
+  ? Predicate<A>
+  : Predicate<A & Record<K, T>>;
 
 /**
  * Checks whether a value has the specified own key.
  *
  * @param key Property key to check.
- * @returns Predicate narrowing to an object with the key present.
+ * @returns Predicate with key-specific narrowing for a singleton literal key,
+ * or object-only narrowing for a multi-value key domain.
  */
-export const hasKey = <K extends PropertyKey>(key: K) =>
-  define<Record<K, unknown>>((input) =>
-    isObject(input) && hasOwnPropertyKey(input, key));
+export function hasKey<const K extends PropertyKey>(
+  key: K
+): Predicate<KeyPresence<K>>;
+export function hasKey(key: PropertyKey): Predicate<object> {
+  return define<object>(
+    (input) => isObject(input) && hasOwnPropertyKey(input, key)
+  );
+}
 
 /**
  * Checks whether a value has all specified own keys.
  *
  * @param keys Property keys to check.
- * @returns Predicate narrowing to an object with all keys present.
+ * @returns Predicate with key-specific narrowing when every argument is a
+ * singleton literal key, or object-only narrowing otherwise.
  */
-export const hasKeys = <
+export function hasKeys<
   const KS extends readonly [PropertyKey, ...PropertyKey[]]
->(
-  ...keys: KS
-) => {
+>(...keys: KS): Predicate<KeyPresences<KS>>;
+export function hasKeys(...keys: readonly PropertyKey[]): Predicate<object> {
   // WHY: Type-level non-empty constraints can be bypassed from JavaScript or `any`.
   // Return a predicate that always fails so misuse does not crash applications.
   if (keys.length === 0) {
-    return define<Record<KS[number], unknown>>(() => false);
+    return define<object>(() => false);
   }
 
-  return define<Record<KS[number], unknown>>(
+  return define<object>(
     (input) => isObject(input) && hasOwnPropertyKeys(input, keys)
   );
-};
-
-/** Detects whether a type represents more than one possible value. */
-type IsUnion<Value, Whole = Value> = Value extends Whole
-  ? [Whole] extends [Value]
-    ? false
-    : true
-  : never;
-
-/** Keeps only one literal property key so one read cannot narrow other keys. */
-type SinglePropertyKey<Key extends PropertyKey> = [Key] extends [never]
-  ? never
-  : true extends IsUnion<Key>
-    ? never
-    : // WHY: Broad, patterned, and opaque key domains produce index
-      // signatures, which an object with no declared properties satisfies.
-      {} extends Record<Key, never>
-      ? never
-      : Key;
-
-/** Keeps only one non-negative integer literal that identifies an array index. */
-type ArrayIndex<Index extends number> =
-  SinglePropertyKey<Index> extends never
-    ? never
-    : `${Index}` extends `-${string}`
-      ? never
-      : `${Index}` extends `${bigint}`
-        ? Index
-        : never;
+}
 
 /**
  * Lifts a required-property refinement to its parent object.
@@ -159,29 +149,24 @@ export function refineIndex<
  * `{ [key]: target }`.
  *
  * @param guard Base guard for objects that include `key`.
- * @param key Property key to narrow.
+ * @param key Property key to compare; singleton literals narrow that property.
  * @returns Builder that takes a literal `target` and returns a guard that
- * narrows `key` to that literal.
+ * narrows a singleton `key` to that literal. Multi-value key domains preserve
+ * only the base guard's type.
  */
-export function narrowKeyTo<A, K extends keyof A>(
+export function narrowKeyTo<A, const K extends keyof A & PropertyKey>(
   guard: Guard<A>,
   key: K
-): <const T extends A[K]>(target: T) => Predicate<A & Record<K, T>>;
-export function narrowKeyTo<
-  K extends PropertyKey,
-  F extends Predicate<Record<K, unknown>>
->(
-  guard: F,
-  key: K
-): <const T>(target: T) => Predicate<GuardedOf<F> & Record<K, T>> {
-  // WHY: Provide two overloads to balance type safety and flexibility.
-  // - When base type A and key K are known, enforce T extends A[K] for precise literal narrowing.
-  // - For generic guards, accept F extends Predicate<Record<K, unknown>> and return GuardedOf<F> & Record<K, T>.
-  //   This keeps the API usable with inferred/anonymous guards.
-  // Use equalsKey for Object.is semantics and own-property presence; wrap with define to coerce the result to boolean for consistent guard behavior (as documented in define), not just to produce a typed Predicate.
-  return <const T>(target: T) => {
+): <const T extends A[K]>(target: T) => NarrowKeyPredicate<A, K, T>;
+export function narrowKeyTo(
+  guard: Guard<unknown>,
+  key: PropertyKey
+): (target: unknown) => Predicate<unknown> {
+  // WHY: A broad or union key remains useful as a runtime check, but only a
+  // singleton key overload may claim that one specific property was narrowed.
+  return (target) => {
     const keyEquals = equalsKey(key, target);
-    return define<GuardedOf<F> & Record<K, T>>(
+    return define<unknown>(
       (input: unknown) => guard(input) && keyEquals(input)
     );
   };

--- a/src/utils/own-properties.ts
+++ b/src/utils/own-properties.ts
@@ -10,10 +10,8 @@
  * @param key Property key to check.
  * @returns Whether `key` is present directly on `value`.
  */
-export const hasOwnPropertyKey = <Value extends object, K extends PropertyKey>(
-  value: Value,
-  key: K
-): value is Value & Record<K, unknown> => Object.hasOwn(value, key);
+export const hasOwnPropertyKey = (value: object, key: PropertyKey): boolean =>
+  Object.hasOwn(value, key);
 
 /**
  * Checks whether an object has every requested own property key.
@@ -23,6 +21,6 @@ export const hasOwnPropertyKey = <Value extends object, K extends PropertyKey>(
  * @returns Whether all keys are present directly on `value`.
  */
 export const hasOwnPropertyKeys = (
-  value: Record<PropertyKey, unknown>,
+  value: object,
   keys: readonly PropertyKey[]
 ): boolean => keys.every((key) => hasOwnPropertyKey(value, key));

--- a/tests-d/core/equals.test-d.ts
+++ b/tests-d/core/equals.test-d.ts
@@ -46,4 +46,25 @@ if (hasKindUser(keyRecordCandidate)) {
   expectType<'user'>(keyRecordCandidate.kind);
 }
 
+// it: keeps union and broad keys callable without narrowing unchecked keys
+declare const selectedKey: 'kind' | 'id';
+declare const broadKey: string;
+const selectedKeyEqualsUser = equalsKey(selectedKey, 'user');
+const dynamicKeyEqualsUser = equalsKey(broadKey, 'user');
+
+expectType<Predicate<object>>(selectedKeyEqualsUser);
+expectType<Predicate<object>>(dynamicKeyEqualsUser);
+expectType<
+  <A extends Record<'kind', unknown>>(
+    input: unknown
+  ) => input is A & Record<'kind', 'user'>
+>(equalsKey<'kind', 'user'>('kind', 'user'));
+expectType<Predicate<object>>(
+  equalsKey<'kind' | 'id', 'user'>(selectedKey, 'user')
+);
+
+if (selectedKeyEqualsUser(keyRecordCandidate)) {
+  expectType<object>(keyRecordCandidate);
+}
+
 // oneOfValues tests moved to tests-d/core/combinators/one-of-values.test-d.ts

--- a/tests-d/core/key.test-d.ts
+++ b/tests-d/core/key.test-d.ts
@@ -100,13 +100,19 @@ if (hasKindAndId(candidate)) {
 // it: falls back when any argument may identify multiple runtime keys
 const hasOneSelectedKey = hasKeys(selectedKey);
 const hasKindAndDynamicKey = hasKeys('kind', broadKey);
+declare const selectedKeyTuple: readonly ['kind'] | readonly ['id'];
+const hasSelectedKeyTuple = hasKeys(...selectedKeyTuple);
 
 expectType<Predicate<object>>(hasOneSelectedKey);
 expectType<Predicate<object>>(hasKindAndDynamicKey);
+expectType<Predicate<object>>(hasSelectedKeyTuple);
 expectType<Predicate<Record<'kind' | 'id', unknown>>>(
   hasKeys<readonly ['kind', 'id']>('kind', 'id')
 );
 expectType<Predicate<object>>(hasKeys<readonly ['kind' | 'id']>(selectedKey));
+expectType<Predicate<object>>(
+  hasKeys<readonly ['kind'] | readonly ['id']>(...selectedKeyTuple)
+);
 
 // it: rejects empty keys at compile time
 expectNotAssignable<Parameters<typeof hasKeys>>([]);

--- a/tests-d/core/key.test-d.ts
+++ b/tests-d/core/key.test-d.ts
@@ -40,6 +40,27 @@ if (isGuest(candidate)) {
   expectType<'guest'>(candidate.role);
 }
 
+// it: keeps union and broad keys callable without narrowing every candidate key
+type Pair = Readonly<{ left: number; right: number }>;
+declare const isPair: Predicate<Pair>;
+declare const selectedPairKey: 'left' | 'right';
+declare const broadDictionaryKey: string;
+declare const isNumberDictionary: Predicate<Readonly<Record<string, number>>>;
+
+const hasSelectedOne = narrowKeyTo(isPair, selectedPairKey)(1);
+const hasDynamicOne = narrowKeyTo(isNumberDictionary, broadDictionaryKey)(1);
+
+expectType<Predicate<Pair>>(hasSelectedOne);
+expectType<Predicate<Readonly<Record<string, number>>>>(hasDynamicOne);
+expectType<Predicate<Pair>>(
+  narrowKeyTo<Pair, 'left' | 'right'>(isPair, selectedPairKey)(1)
+);
+
+if (hasSelectedOne(candidate)) {
+  expectType<number>(candidate.left);
+  expectType<number>(candidate.right);
+}
+
 // =============================================
 // describe: hasKey
 // =============================================
@@ -48,6 +69,21 @@ const hasKind = hasKey('kind');
 if (hasKind(candidate)) {
   expectType<Record<'kind', unknown>>(candidate);
   expectType<unknown>(candidate.kind);
+}
+
+// it: keeps dynamic key checks callable without claiming every possible key
+declare const selectedKey: 'kind' | 'id';
+declare const broadKey: string;
+const hasSelectedKey = hasKey(selectedKey);
+const hasDynamicKey = hasKey(broadKey);
+
+expectType<Predicate<object>>(hasSelectedKey);
+expectType<Predicate<object>>(hasDynamicKey);
+expectType<Predicate<Record<'kind', unknown>>>(hasKey<'kind'>('kind'));
+expectType<Predicate<object>>(hasKey<'kind' | 'id'>(selectedKey));
+
+if (hasSelectedKey(candidate)) {
+  expectType<object>(candidate);
 }
 
 // =============================================
@@ -60,6 +96,17 @@ if (hasKindAndId(candidate)) {
   expectType<unknown>(candidate.kind);
   expectType<unknown>(candidate.id);
 }
+
+// it: falls back when any argument may identify multiple runtime keys
+const hasOneSelectedKey = hasKeys(selectedKey);
+const hasKindAndDynamicKey = hasKeys('kind', broadKey);
+
+expectType<Predicate<object>>(hasOneSelectedKey);
+expectType<Predicate<object>>(hasKindAndDynamicKey);
+expectType<Predicate<Record<'kind' | 'id', unknown>>>(
+  hasKeys<readonly ['kind', 'id']>('kind', 'id')
+);
+expectType<Predicate<object>>(hasKeys<readonly ['kind' | 'id']>(selectedKey));
 
 // it: rejects empty keys at compile time
 expectNotAssignable<Parameters<typeof hasKeys>>([]);

--- a/tests/core/equals.test.ts
+++ b/tests/core/equals.test.ts
@@ -55,6 +55,15 @@ describe('equalsKey', () => {
 
     expect(isUser(nil)).toBe(true);
   });
+
+  it('compares only the runtime-selected key from a union', () => {
+    const createSelectedKeyComparator = (key: 'kind' | 'id') =>
+      equalsKey(key, 'user');
+    const selectedKindIsUser = createSelectedKeyComparator('kind');
+
+    expect(selectedKindIsUser({ kind: 'user' })).toBe(true);
+    expect(selectedKindIsUser({ id: 'user' })).toBe(false);
+  });
 });
 
 // oneOfValues tests moved to tests/core/combinators/one-of-values.test.ts

--- a/tests/core/key.test.ts
+++ b/tests/core/key.test.ts
@@ -37,6 +37,15 @@ describe('key: narrowKeyTo', () => {
     expect(isGuest(admin)).toBe(false);
     expect(isTrial(admin)).toBe(false);
   });
+
+  it('checks only the runtime-selected key from a union', () => {
+    const createSelectedKeyGuard = (key: 'age' | 'role') =>
+      narrowKeyTo(isUser, key)(20);
+    const hasSelectedAge = createSelectedKeyGuard('age');
+
+    expect(hasSelectedAge({ id: '1', age: 20, role: 'guest' })).toBe(true);
+    expect(hasSelectedAge({ id: '1', age: 21, role: 'guest' })).toBe(false);
+  });
 });
 
 describe('key: hasKey', () => {
@@ -62,6 +71,14 @@ describe('key: hasKey', () => {
     const value = Object.create(null) as Record<'kind', unknown>;
     value.kind = 'guest';
     expect(hasKind(value)).toBe(true);
+  });
+
+  it('checks only the runtime-selected key from a union', () => {
+    const createSelectedKeyGuard = (key: 'kind' | 'id') => hasKey(key);
+    const hasSelectedKind = createSelectedKeyGuard('kind');
+
+    expect(hasSelectedKind({ kind: 'user' })).toBe(true);
+    expect(hasSelectedKind({ id: 1 })).toBe(false);
   });
 });
 
@@ -99,6 +116,17 @@ describe('key: hasKeys', () => {
     expect(guard({ kind: 'user', id: 1 })).toBe(false);
     expect(guard({})).toBe(false);
     expect(guard(null)).toBe(false);
+  });
+
+  it('checks only each runtime-selected key from union arguments', () => {
+    const createSelectedKeysGuard = (
+      first: 'kind' | 'id',
+      second: 'name' | 'role'
+    ) => hasKeys(first, second);
+    const hasKindAndName = createSelectedKeysGuard('kind', 'name');
+
+    expect(hasKindAndName({ kind: 'user', name: 'Ada' })).toBe(true);
+    expect(hasKindAndName({ id: 1, role: 'admin' })).toBe(false);
   });
 });
 

--- a/tests/typescript-compatibility/consumer.ts
+++ b/tests/typescript-compatibility/consumer.ts
@@ -1,5 +1,15 @@
 import * as ts from 'typescript-api';
-import { and, oneOf, refineDefinedKey, refineIndex, refineKey } from 'is-kit';
+import {
+  and,
+  equalsKey,
+  hasKey,
+  hasKeys,
+  narrowKeyTo,
+  oneOf,
+  refineDefinedKey,
+  refineIndex,
+  refineKey
+} from 'is-kit';
 
 // =============================================
 // describe: published declaration compatibility
@@ -85,6 +95,44 @@ declare const broadKey: string;
 declare const unionKey: 'expression' | 'arguments';
 declare const patternedKey: `child-${string}`;
 declare const brandedNumberKey: number & { readonly brand: 'property-key' };
+
+// it: keeps multi-value key helpers callable without over-narrowing
+type Pair = { readonly left: number; readonly right: number };
+declare const isPair: (value: unknown) => value is Pair;
+declare const selectedPairKey: 'left' | 'right';
+const hasSelectedKey = hasKey(selectedPairKey);
+const hasSelectedKeys = hasKeys(selectedPairKey);
+const selectedKeyEqualsValue = equalsKey(selectedPairKey, 1);
+const selectedValueEqualsOne = narrowKeyTo(isPair, selectedPairKey)(1);
+
+declare let unknownValue: unknown;
+if (hasSelectedKey(unknownValue)) {
+  const objectValue: object = unknownValue;
+  void objectValue;
+  // @ts-expect-error: A union key does not prove that left exists.
+  const left = unknownValue.left;
+  void left;
+}
+
+if (hasSelectedKeys(unknownValue)) {
+  // @ts-expect-error: A union argument checks one runtime key, not both.
+  const right = unknownValue.right;
+  void right;
+}
+
+if (selectedKeyEqualsValue(unknownValue)) {
+  // @ts-expect-error: Equality at one selected key does not narrow left.
+  const left = unknownValue.left;
+  void left;
+}
+
+if (selectedValueEqualsOne(unknownValue)) {
+  const pair: Pair = unknownValue;
+  void pair;
+  // @ts-expect-error: Neither property is known to equal the target literal.
+  const left: 1 = unknownValue.left;
+  void left;
+}
 
 // @ts-expect-error: A broad string does not identify one property.
 refineKey(broadKey, ts.isIdentifier);

--- a/tests/typescript-compatibility/consumer.ts
+++ b/tests/typescript-compatibility/consumer.ts
@@ -100,8 +100,10 @@ declare const brandedNumberKey: number & { readonly brand: 'property-key' };
 type Pair = { readonly left: number; readonly right: number };
 declare const isPair: (value: unknown) => value is Pair;
 declare const selectedPairKey: 'left' | 'right';
+declare const selectedPairKeyTuple: readonly ['left'] | readonly ['right'];
 const hasSelectedKey = hasKey(selectedPairKey);
 const hasSelectedKeys = hasKeys(selectedPairKey);
+const hasSelectedKeyTuple = hasKeys(...selectedPairKeyTuple);
 const selectedKeyEqualsValue = equalsKey(selectedPairKey, 1);
 const selectedValueEqualsOne = narrowKeyTo(isPair, selectedPairKey)(1);
 
@@ -118,6 +120,12 @@ if (hasSelectedKeys(unknownValue)) {
   // @ts-expect-error: A union argument checks one runtime key, not both.
   const right = unknownValue.right;
   void right;
+}
+
+if (hasSelectedKeyTuple(unknownValue)) {
+  // @ts-expect-error: A tuple union supplies one runtime tuple, not every key.
+  const left = unknownValue.left;
+  void left;
 }
 
 if (selectedKeyEqualsValue(unknownValue)) {


### PR DESCRIPTION
## Summary

Prevent key helpers from over-narrowing union key.

<!-- A brief summary of the changes -->

## Description

- preserve precise narrowing for singleton literal keys
- fall back to object-only or base-guard narrowing for union and broad keys
- apply the safe behavior to `hasKey`, `hasKeys`, `equalsKey`, and `narrowKeyTo`

<!-- A detailed explanation of the changes, including why they are needed -->
