### PR TITLE
perf: avoid exception-driven typed array checks

### DIFF
--- a/.codex/skills/learn/LEARNED_INDEX.md
+++ b/.codex/skills/learn/LEARNED_INDEX.md
@@ -1,9 +1,11 @@
 # Learned Patterns
 
+- **[balance-runtime-cost-with-compositional-design](learned/balance-runtime-cost-with-compositional-design.md)** - Require meaningful absolute-cost evidence before replacing is-kit's compositional built-in guards with direct predicates.
 - **[deprecate-public-api-before-major-removal](learned/deprecate-public-api-before-major-removal.md)** - Deprecate accidental runtime exports during the current major before removing only their public entry point in the next major.
 - **[keep-typed-schema-key-coverage-explicit](learned/keep-typed-schema-key-coverage-explicit.md)** - Match typed schema drift claims to the string-key coverage enforced by both mapped types and runtime enumeration.
 - **[model-transformations-as-decoders](learned/model-transformations-as-decoders.md)** - Model value-changing boundary conversions as ParseResult-returning decoder functions rather than type guards.
 - **[order-precise-overloads-before-generic-fallbacks](learned/order-precise-overloads-before-generic-fallbacks.md)** - Put tuple-preserving overloads before homogeneous array fallbacks so concrete chains retain their final narrowing.
+- **[prefer-non-throwing-intrinsic-brand-checks](learned/prefer-non-throwing-intrinsic-brand-checks.md)** - Prefer captured intrinsic accessors that distinguish built-in brands without exceptions on successful validation paths.
 - **[preserve-explicit-generic-call-compatibility](learned/preserve-explicit-generic-call-compatibility.md)** - Treat public type-parameter shape as source API and test explicit generic calls when generalizing signatures.
 - **[preserve-type-guard-semantics-across-host-values](learned/preserve-type-guard-semantics-across-host-values.md)** - Keep a type guard's runtime set exact across host values such as browser `document.all` when optimizing primitive checks.
 - **[require-singleton-keys-for-single-property-refinements](learned/require-singleton-keys-for-single-property-refinements.md)** - Reuse one mapped-type constraint to reject union, broad, patterned, and branded key domains before narrowing one property.

--- a/.codex/skills/learn/learned/balance-runtime-cost-with-compositional-design.md
+++ b/.codex/skills/learn/learned/balance-runtime-cost-with-compositional-design.md
@@ -1,0 +1,57 @@
+# Balance Runtime Cost With Compositional Design
+
+**Captured:** 2026-09-05
+**Context:** Refactoring built-in guards that are implemented with is-kit's public composition helpers
+**Tags:** typescript, type-guards, performance, benchmarking, api-design, composition
+
+## Problem
+
+A direct predicate can benchmark several times faster than the same check built
+with `define`, `and`, or `or`. Relative ratios alone can make the composed
+version appear unacceptably expensive even when the absolute difference is only
+a few nanoseconds per call. Flattening every built-in guard also removes the
+library's own examples and exercise of its composition model, weakening the
+architectural message for users.
+
+## Solution
+
+Treat composition as the default for is-kit's built-in guards. Before replacing
+it, measure both relative and absolute cost in a production-shaped workload and
+estimate a realistic call volume. Depart from composition when it violates the
+runtime/type contract, relies on unusually expensive control flow such as
+expected exceptions, or creates a demonstrated material bottleneck.
+
+Correctness remains non-negotiable: a small direct check is appropriate when a
+composed or abbreviated form accepts values outside the declared type. Pure
+microbenchmark wins must also outweigh the value of dogfooding the public API
+before they justify architectural inconsistency.
+
+## Example
+
+```ts
+export const isPositive = and(
+  isNumber,
+  predicateToRefine<number>((value) => value > 0)
+);
+```
+
+Although the equivalent direct predicate removes several calls, retain the
+composition unless realistic profiling shows that its absolute cost matters.
+In contrast, use strict direct comparisons for nullish guards when loose
+equality would classify browser `document.all` outside the promised type.
+
+## When To Use
+
+Apply this decision process when reviewing wrappers, callbacks, or combinators
+on runtime validation paths. Include warm-up and mixed inputs in benchmarks,
+report nanoseconds or elapsed workload time alongside ratios, and verify the
+chosen implementation with lint, build, Jest, and `tsd`.
+
+## Related Files
+
+- `runtime-guard-refactoring-design.md`
+- `src/core/primitive.ts`
+- `src/core/logic.ts`
+- `src/core/define.ts`
+- `tests/core/primitive.test.ts`
+- `tests-d/core/primitive.test-d.ts`

--- a/.codex/skills/learn/learned/prefer-non-throwing-intrinsic-brand-checks.md
+++ b/.codex/skills/learn/learned/prefer-non-throwing-intrinsic-brand-checks.md
@@ -1,0 +1,57 @@
+# Prefer Non-Throwing Intrinsic Brand Checks
+
+**Captured:** 2026-09-05
+**Context:** Distinguishing related built-in objects without `instanceof` or spoofable object tags
+**Tags:** typescript, type-guards, runtime-validation, built-ins, cross-realm, performance
+
+## Problem
+
+Captured intrinsic methods and accessors are reliable brand checks because they
+inspect internal slots, accept cross-realm instances, and reject
+`Symbol.toStringTag` spoofing. However, a throwing accessor can be the wrong
+intrinsic for a common path. The previous `isTypedArray` called the captured
+`DataView.prototype.buffer` getter and interpreted its expected `TypeError` as
+evidence that every valid typed array was not a DataView. This made exceptions
+part of the successful typed-array path.
+
+## Solution
+
+Inspect the specification for another captured intrinsic whose normal result
+distinguishes the brands. `%TypedArray%.prototype[Symbol.toStringTag]` checks the
+`[[TypedArrayName]]` internal slot directly: it returns the typed-array name for
+a genuine typed array and `undefined` for DataView and other values. Calling the
+captured getter does not read an object's own spoofable tag.
+
+Keep the public composition pattern where practical. The optimization belongs
+inside the primitive brand check and is justified by removing exception-driven
+normal control flow, not merely by shortening the predicate.
+
+## Example
+
+```ts
+const typedArrayName = Object.getOwnPropertyDescriptor(
+  Object.getPrototypeOf(Uint8Array.prototype),
+  Symbol.toStringTag
+)?.get;
+
+export const isTypedArray = define<ArrayBufferView>(
+  (value) => typedArrayName?.call(value) !== undefined
+);
+```
+
+## When To Use
+
+Use this approach when two related built-in brands share a broad platform check
+and one is currently excluded by catching an expected exception. Verify the
+chosen accessor against the ECMAScript algorithm and test every supported
+constructor, DataView or sibling-brand rejection, cross-realm values,
+subclasses, proxies, spoofed tags, and detached or out-of-bounds buffers.
+
+Measure the absolute success-path cost as well as the relative improvement, and
+run the check in at least one browser when the package supports browsers.
+
+## Related Files
+
+- `src/core/object.ts`
+- `tests/core/object.test.ts`
+- `runtime-guard-refactoring-design.md`

--- a/src/core/object.ts
+++ b/src/core/object.ts
@@ -54,6 +54,10 @@ const arrayBufferByteLength = getIntrinsicGetter(
   'byteLength'
 );
 const dataViewBuffer = getIntrinsicGetter(DataView.prototype, 'buffer');
+const typedArrayName = Object.getOwnPropertyDescriptor(
+  Object.getPrototypeOf(Uint8Array.prototype),
+  Symbol.toStringTag
+)?.get;
 
 const defineOptionalInstanceGuard = <T>(
   constructor: InstanceCheckTarget<T> | undefined
@@ -214,8 +218,11 @@ export const isDataView = defineIntrinsicBrandGuard<DataView>((value) =>
  *
  * @returns Predicate narrowing to `ArrayBufferView`.
  */
+// WHY: The captured %TypedArray%.prototype @@toStringTag getter checks the
+// internal TypedArray name without trusting a spoofable property. It returns
+// undefined for DataView and other values instead of rejecting them by exception.
 export const isTypedArray = define<ArrayBufferView>(
-  (value) => ArrayBuffer.isView(value) && !isDataView(value)
+  (value) => typedArrayName?.call(value) !== undefined
 );
 
 /**

--- a/tests/core/object.test.ts
+++ b/tests/core/object.test.ts
@@ -88,7 +88,8 @@ describe('core/object guards', () => {
       weakMap: new WeakMap(),
       weakSet: new WeakSet(),
       arrayBuffer: new ArrayBuffer(8),
-      dataView: new DataView(new ArrayBuffer(8))
+      dataView: new DataView(new ArrayBuffer(8)),
+      typedArray: new Uint16Array(2)
     })`) as Record<string, unknown>;
 
     expect(isDate(values.date)).toBe(true);
@@ -99,6 +100,7 @@ describe('core/object guards', () => {
     expect(isWeakSet(values.weakSet)).toBe(true);
     expect(isArrayBuffer(values.arrayBuffer)).toBe(true);
     expect(isDataView(values.dataView)).toBe(true);
+    expect(isTypedArray(values.typedArray)).toBe(true);
   });
 
   it('accepts built-in subclasses while preserving valid Date semantics', () => {
@@ -145,9 +147,25 @@ describe('core/object guards', () => {
   });
 
   it('handles typed arrays and buffers', () => {
+    const typedArrays: readonly ArrayBufferView[] = [
+      new Int8Array(2),
+      new Uint8Array(2),
+      new Uint8ClampedArray(2),
+      new Int16Array(2),
+      new Uint16Array(2),
+      new Int32Array(2),
+      new Uint32Array(2),
+      new Float32Array(2),
+      new Float64Array(2),
+      new BigInt64Array(2),
+      new BigUint64Array(2)
+    ];
+
     expect(isArrayBuffer(new ArrayBuffer(8))).toBe(true);
     expect(isDataView(new DataView(new ArrayBuffer(8)))).toBe(true);
-    expect(isTypedArray(new Uint8Array(2))).toBe(true);
+    for (const typedArray of typedArrays) {
+      expect(isTypedArray(typedArray)).toBe(true);
+    }
     expect(isTypedArray(new DataView(new ArrayBuffer(8)))).toBe(false);
 
     const spoofedDataView = new DataView(new ArrayBuffer(8));
@@ -157,6 +175,16 @@ describe('core/object guards', () => {
     expect(isDataView(spoofedDataView)).toBe(true);
     expect(isTypedArray(spoofedDataView)).toBe(false);
 
+    const spoofedTypedArray = new Uint8Array(2);
+    Object.defineProperty(spoofedTypedArray, Symbol.toStringTag, {
+      value: 'DataView'
+    });
+    expect(isTypedArray(spoofedTypedArray)).toBe(true);
+
+    class TypedArraySubclass extends Uint8Array {}
+    expect(isTypedArray(new TypedArraySubclass(2))).toBe(true);
+    expect(isTypedArray(new Proxy(new Uint8Array(2), {}))).toBe(false);
+
     const transferredBuffer = new ArrayBuffer(8);
     const detachedDataView = new DataView(transferredBuffer);
     structuredClone(transferredBuffer, { transfer: [transferredBuffer] });
@@ -165,6 +193,13 @@ describe('core/object guards', () => {
     expect(() => detachedDataView.byteLength).toThrow(TypeError);
     expect(isDataView(detachedDataView)).toBe(true);
     expect(isTypedArray(detachedDataView)).toBe(false);
+
+    const typedArrayBuffer = new ArrayBuffer(8);
+    const detachedTypedArray = new Uint8Array(typedArrayBuffer);
+    structuredClone(typedArrayBuffer, { transfer: [typedArrayBuffer] });
+
+    expect(ArrayBuffer.isView(detachedTypedArray)).toBe(true);
+    expect(isTypedArray(detachedTypedArray)).toBe(true);
   });
 
   it('detects Error, URL, Blob, File', () => {


### PR DESCRIPTION
## Summary

Avoid exception-driven typed array checks

<!-- A brief summary of the changes -->

## Description

- replace the exception-driven `isTypedArray` check with the captured `TypedArray.prototype[Symbol.toStringTag]` getter
- preserve the existing `define` composition, public predicate type, cross-realm behavior, and spoof resistance
- cover all ES2022 typed-array constructors, DataView rejection, subclasses, proxies, spoofed tags, cross-realm values, and detached buffers

  The previous implementation evaluated:

```ts
  ArrayBuffer.isView(value) && !isDataView(value)
```

For every genuine typed array, the captured `DataView.prototype.buffer` getter threw a TypeError, which was then caught to produce a successful result. This made exception handling part of the common success path.

The captured `TypedArray.prototype[Symbol.toStringTag]` getter checks the internal `[[TypedArrayName]]` slot directly. It returns the typed-array name for genuine typed arrays and undefined for `DataView` and other values without trusting an object's own `Symbol.toStringTag`.

Specification: https://tc39.es/ecma262/2026/multipage/indexed-collections.html#sec-get-%typedarray%.prototype-@@tostringtag

<!-- A detailed explanation of the changes, including why they are needed -->
