### PR TITLE
fix: export lazy from core barrel

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -3,6 +3,7 @@ export * from './combinators';
 export * from './define';
 export * from './equals';
 export * from './key';
+export * from './lazy';
 export * from './logic';
 export * from './nullish';
 export * from './object';

--- a/tests-d/core/lazy.test-d.ts
+++ b/tests-d/core/lazy.test-d.ts
@@ -1,5 +1,6 @@
 import { expectType } from 'tsd';
-import { arrayOf, lazy, typedStruct } from '@/index';
+import { lazy } from '@/core';
+import { arrayOf, typedStruct } from '@/core/combinators';
 import { isString } from '@/core/primitive';
 import type { Predicate } from '@/types';
 


### PR DESCRIPTION
## Summary

Export lazy from core barrel.

<!-- A brief summary of the changes -->

## Description

Adds lazy to the internal `@/core` barrel export so it matches the available core API. 
Updates the existing type test to import lazy through the barrel, preventing regressions.

<!-- A detailed explanation of the changes, including why they are needed -->
