### PR TITLE
test: cover practical property refinement composition

### DIFF
--- a/tests-d/core/key.test-d.ts
+++ b/tests-d/core/key.test-d.ts
@@ -228,6 +228,7 @@ if (hasReadyTextPayload(envelope)) {
   // a more specific caller property, so assert assignability rather than an
   // identical displayed intersection type.
   expectAssignable<string>(envelope.payload.body);
+  expectAssignable<typeof envelope.payload.body>('body');
 }
 
 declare const dynamicIndex: number;

--- a/tests-d/core/key.test-d.ts
+++ b/tests-d/core/key.test-d.ts
@@ -1,4 +1,4 @@
-import { expectNotAssignable, expectType } from 'tsd';
+import { expectAssignable, expectNotAssignable, expectType } from 'tsd';
 import {
   hasKey,
   hasKeys,
@@ -9,7 +9,9 @@ import {
   struct,
   isString,
   isNumber,
-  oneOfValues
+  oneOfValues,
+  andAll,
+  equals
 } from 'is-kit';
 import type { Predicate, Refinement } from 'is-kit';
 
@@ -182,6 +184,50 @@ declare let tuple: readonly [string | number, boolean];
 if (hasStringAtZero(tuple)) {
   expectType<string>(tuple[0]);
   expectType<boolean>(tuple[1]);
+}
+
+// =============================================
+// describe: practical property refinement composition
+// =============================================
+// it: preserves a defined optional API field through Array.filter
+type Job = {
+  readonly id: string;
+  readonly result?: string | Uint8Array;
+};
+
+declare const jobs: readonly Job[];
+const completedTextJobs = jobs.filter(refineDefinedKey('result', isString));
+
+expectType<Array<Job & Record<'result', string>>>(completedTextJobs);
+
+// it: lifts nested discriminant and field refinements to an envelope
+type TextPayload = {
+  readonly kind: 'text';
+  readonly status: 'pending' | 'ready';
+  readonly body: string | Uint8Array;
+};
+type BinaryPayload = { readonly kind: 'binary'; readonly bytes: Uint8Array };
+type Envelope = { readonly payload: TextPayload | BinaryPayload };
+
+const isTextPayload = (
+  payload: TextPayload | BinaryPayload
+): payload is TextPayload => payload.kind === 'text';
+const hasReadyTextPayload = refineKey(
+  'payload',
+  andAll(
+    isTextPayload,
+    refineKey('status', equals('ready')),
+    refineKey('body', isString)
+  )
+);
+
+declare let envelope: Envelope;
+if (hasReadyTextPayload(envelope)) {
+  expectType<'ready'>(envelope.payload.status);
+  // Note: The parent intersection prevents a generic refinement from widening
+  // a more specific caller property, so assert assignability rather than an
+  // identical displayed intersection type.
+  expectAssignable<string>(envelope.payload.body);
 }
 
 declare const dynamicIndex: number;

--- a/tests/core/key.test.ts
+++ b/tests/core/key.test.ts
@@ -9,7 +9,8 @@ import {
 import { struct } from '@/core/combinators';
 import { isString, isNumber } from '@/core/primitive';
 import { oneOfValues } from '@/core/combinators/one-of-values';
-import { and } from '@/core/logic';
+import { and, andAll } from '@/core/logic';
+import { equals } from '@/core/equals';
 
 const isUser = struct({
   id: isString,
@@ -325,5 +326,46 @@ describe('key: refineIndex', () => {
     expect(refinement(value)).toBe(true);
     expect(reads).toBe(1);
     expect(calls).toBe(1);
+  });
+});
+
+describe('key: practical property refinement composition', () => {
+  type TextPayload = {
+    readonly kind: 'text';
+    readonly status: 'pending' | 'ready';
+    readonly body: string | Uint8Array;
+  };
+  type BinaryPayload = {
+    readonly kind: 'binary';
+    readonly bytes: Uint8Array;
+  };
+  type Envelope = { readonly payload: TextPayload | BinaryPayload };
+
+  const isTextPayload = (
+    payload: TextPayload | BinaryPayload
+  ): payload is TextPayload => payload.kind === 'text';
+  const hasReadyTextPayload = refineKey(
+    'payload',
+    andAll(
+      isTextPayload,
+      refineKey('status', equals('ready')),
+      refineKey('body', isString)
+    )
+  );
+
+  it('accepts a ready text payload with a string body', () => {
+    const value: Envelope = {
+      payload: { kind: 'text', status: 'ready', body: 'Hello' }
+    };
+
+    expect(hasReadyTextPayload(value)).toBe(true);
+  });
+
+  it.each<Envelope>([
+    { payload: { kind: 'binary', bytes: new Uint8Array() } },
+    { payload: { kind: 'text', status: 'pending', body: 'Hello' } },
+    { payload: { kind: 'text', status: 'ready', body: new Uint8Array() } }
+  ])('rejects a payload that misses one nested refinement', (value) => {
+    expect(hasReadyTextPayload(value)).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Cover practical property refinement composition.

<!-- A brief summary of the changes -->

## Description

- Nested discriminated payload narrowing with `refineKey` and `andAll`
- Optional API fields narrowed through `Array.prototype.filter`

<!-- A detailed explanation of the changes, including why they are needed -->
